### PR TITLE
Add nRF52/nRF53/nRF91 and some test boards

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840_v1/Kconfig
+++ b/boards/arm/nrf52840dk_nrf52840_v1/Kconfig
@@ -1,0 +1,18 @@
+# nRF52840 DK NRF52840 board configuration
+
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF52840DK_NRF52840_V1
+
+config BOARD_ENABLE_DCDC
+	bool "DCDC mode"
+	select SOC_DCDC_NRF52X
+	default y
+
+config BOARD_ENABLE_DCDC_HV
+	bool "High Voltage DCDC converter"
+	select SOC_DCDC_NRF52X_HV
+	default y
+
+endif # BOARD_NRF52840DK_NRF52840_V1

--- a/boards/arm/nrf52840dk_nrf52840_v1/Kconfig.board
+++ b/boards/arm/nrf52840dk_nrf52840_v1/Kconfig.board
@@ -1,0 +1,8 @@
+# nRF52840 DK NRF52840 board configuration
+
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NRF52840DK_NRF52840_V1
+	bool "nRF52840 DK NRF52840 v1"
+	depends on SOC_NRF52840_QIAA

--- a/boards/arm/nrf52840dk_nrf52840_v1/Kconfig.defconfig
+++ b/boards/arm/nrf52840dk_nrf52840_v1/Kconfig.defconfig
@@ -1,0 +1,14 @@
+# nRF52840 DK NRF52840 board configuration
+
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF52840DK_NRF52840_V1
+
+config BOARD
+	default "nrf52840dk_nrf52840_v1"
+
+config BT_CTLR
+	default BT
+
+endif # BOARD_NRF52840DK_NRF52840

--- a/boards/arm/nrf52840dk_nrf52840_v1/board.cmake
+++ b/boards/arm/nrf52840dk_nrf52840_v1/board.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>,
+				<NRF_PSEL(UART_RX, 0, 8)>,
+				<NRF_PSEL(UART_RTS, 0, 5)>,
+				<NRF_PSEL(UART_CTS, 0, 7)>;
+			low-power-enable;
+		};
+	};
+
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 1, 1)>;
+			bias-pull-up;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 1, 2)>;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_RX, 1, 1)>,
+				<NRF_PSEL(UART_TX, 1, 2)>;
+			low-power-enable;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
+				<NRF_PSEL(TWIM_SCL, 0, 27)>;
+		};
+	};
+
+	i2c0_sleep: i2c0_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
+				<NRF_PSEL(TWIM_SCL, 0, 27)>;
+			low-power-enable;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
+				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+		};
+	};
+
+	i2c1_sleep: i2c1_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
+				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+			low-power-enable;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>;
+			nordic,invert;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>;
+			low-power-enable;
+		};
+	};
+
+	spi0_default: spi0_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 27)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 26)>,
+				<NRF_PSEL(SPIM_MISO, 0, 29)>;
+		};
+	};
+
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 27)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 26)>,
+				<NRF_PSEL(SPIM_MISO, 0, 29)>;
+			low-power-enable;
+		};
+	};
+
+	spi1_default: spi1_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 31)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIM_MISO, 1, 8)>;
+		};
+	};
+
+	spi1_sleep: spi1_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 31)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIM_MISO, 1, 8)>;
+			low-power-enable;
+		};
+	};
+
+	spi2_default: spi2_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
+				<NRF_PSEL(SPIM_MISO, 0, 21)>;
+		};
+	};
+
+	spi2_sleep: spi2_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
+				<NRF_PSEL(SPIM_MISO, 0, 21)>;
+			low-power-enable;
+		};
+	};
+
+	qspi_default: qspi_default {
+		group1 {
+			psels = <NRF_PSEL(QSPI_SCK, 0, 19)>,
+				<NRF_PSEL(QSPI_IO0, 0, 20)>,
+				<NRF_PSEL(QSPI_IO1, 0, 21)>,
+				<NRF_PSEL(QSPI_IO2, 0, 22)>,
+				<NRF_PSEL(QSPI_IO3, 0, 23)>,
+				<NRF_PSEL(QSPI_CSN, 0, 17)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+
+	qspi_sleep: qspi_sleep {
+		group1 {
+			psels = <NRF_PSEL(QSPI_SCK, 0, 19)>,
+				<NRF_PSEL(QSPI_IO0, 0, 20)>,
+				<NRF_PSEL(QSPI_IO1, 0, 21)>,
+				<NRF_PSEL(QSPI_IO2, 0, 22)>,
+				<NRF_PSEL(QSPI_IO3, 0, 23)>;
+			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 17)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			low-power-enable;
+		};
+	};
+
+};

--- a/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1.dts
+++ b/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1.dts
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+#include "nrf52840dk_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "Nordic nRF52840 DK NRF52840";
+	compatible = "nordic,nrf52840-dk-nrf52840";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			label = "Green LED 0";
+		};
+		led1: led_1 {
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			label = "Green LED 1";
+		};
+		led2: led_2 {
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			label = "Green LED 2";
+		};
+		led3: led_3 {
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		button1: button_1 {
+			gpios = <&gpio0 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+		button2: button_2 {
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 2";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+		button3: button_3 {
+			gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch 3";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
+			   <1 0 &gpio0 4 0>,	/* A1 */
+			   <2 0 &gpio0 28 0>,	/* A2 */
+			   <3 0 &gpio0 29 0>,	/* A3 */
+			   <4 0 &gpio0 30 0>,	/* A4 */
+			   <5 0 &gpio0 31 0>,	/* A5 */
+			   <6 0 &gpio1 1 0>,	/* D0 */
+			   <7 0 &gpio1 2 0>,	/* D1 */
+			   <8 0 &gpio1 3 0>,	/* D2 */
+			   <9 0 &gpio1 4 0>,	/* D3 */
+			   <10 0 &gpio1 5 0>,	/* D4 */
+			   <11 0 &gpio1 6 0>,	/* D5 */
+			   <12 0 &gpio1 7 0>,	/* D6 */
+			   <13 0 &gpio1 8 0>,	/* D7 */
+			   <14 0 &gpio1 10 0>,	/* D8 */
+			   <15 0 &gpio1 11 0>,	/* D9 */
+			   <16 0 &gpio1 12 0>,	/* D10 */
+			   <17 0 &gpio1 13 0>,	/* D11 */
+			   <18 0 &gpio1 14 0>,	/* D12 */
+			   <19 0 &gpio1 15 0>,	/* D13 */
+			   <20 0 &gpio0 26 0>,	/* D14 */
+			   <21 0 &gpio0 27 0>;	/* D15 */
+	};
+
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc 1>,	/* A0 = P0.3 = AIN1 */
+				 <1 &adc 2>,	/* A1 = P0.4 = AIN2 */
+				 <2 &adc 4>,	/* A2 = P0.28 = AIN4 */
+				 <3 &adc 5>,	/* A3 = P0.29 = AIN5 */
+				 <4 &adc 6>,	/* A4 = P0.30 = AIN6 */
+				 <5 &adc 7>;	/* A5 = P0.31 = AIN7 */
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		pwm-led0 = &pwm_led0;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
+	};
+};
+
+&adc {
+	status = "okay";
+};
+
+&uicr {
+	gpio-as-nreset;
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+	gpio-reserved-ranges = <0 2>, <6 1>, <8 3>, <17 7>;
+	gpio-line-names = "XL1", "XL2", "AREF", "A0", "A1", "RTS", "TXD",
+		"CTS", "RXD", "NFC1", "NFC2", "BUTTON1", "BUTTON2", "LED1",
+		"LED2", "LED3", "LED4", "QSPI CS", "RESET", "QSPI CLK",
+		"QSPI DIO0", "QSPI DIO1", "QSPI DIO2", "QSPI DIO3","BUTTON3",
+		"BUTTON4", "SDA", "SCL", "A2", "A3", "A4", "A5";
+};
+
+&gpio1 {
+	status = "okay";
+	gpio-line-names = "", "D0", "D1", "D2", "D3", "D4", "D5", "D6",
+		"D7", "", "D8", "D9", "D10", "D11", "D12", "D13";
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_serial: &uart1 {
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_i2c: &i2c0 {
+	compatible = "nordic,nrf-twi";
+	status = "okay";
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-1 = <&i2c0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&i2c1 {
+	compatible = "nordic,nrf-twi";
+	/* Cannot be used together with spi1. */
+	/* status = "okay"; */
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-1 = <&i2c1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&spi0 {
+	compatible = "nordic,nrf-spi";
+	/* Cannot be used together with i2c0. */
+	/* status = "okay"; */
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&spi1 {
+	compatible = "nordic,nrf-spi";
+	status = "okay";
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&spi2 {
+	compatible = "nordic,nrf-spi";
+	status = "disabled";
+	pinctrl-0 = <&spi2_default>;
+	pinctrl-1 = <&spi2_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&qspi {
+	status = "okay";
+	pinctrl-0 = <&qspi_default>;
+	pinctrl-1 = <&qspi_sleep>;
+	pinctrl-names = "default", "sleep";
+	mx25r64: mx25r6435f@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		/* MX25R64 supports only pp and pp4io */
+		writeoc = "pp4io";
+		/* MX25R64 supports all readoc options */
+		readoc = "read4io";
+		sck-frequency = <8000000>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};
+
+arduino_spi: &spi3 {
+	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x0000C000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x00076000>;
+		};
+		slot1_partition: partition@82000 {
+			label = "image-1";
+			reg = <0x00082000 0x00076000>;
+		};
+
+		/*
+		 * The flash starting at 0x000f8000 and ending at
+		 * 0x000fffff is reserved for use by the application.
+		 */
+
+		/*
+		 * Storage partition will be used by FCB/LittleFS/NVS
+		 * if enabled.
+		 */
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 0x00008000>;
+		};
+	};
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};

--- a/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1.yaml
+++ b/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1.yaml
@@ -1,0 +1,28 @@
+identifier: nrf52840dk_nrf52840
+name: nRF52840-DK-NRF52840
+type: mcu
+arch: arm
+ram: 256
+flash: 1024
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - adc
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
+  - ble
+  - counter
+  - gpio
+  - i2c
+  - i2s
+  - pwm
+  - spi
+  - usb_cdc
+  - usb_device
+  - watchdog
+  - netif:openthread
+vendor: nordic

--- a/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1_defconfig
+++ b/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1_defconfig
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF52X=y
+CONFIG_SOC_NRF52840_QIAA=y
+CONFIG_BOARD_NRF52840DK_NRF52840_V1=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable RTT
+CONFIG_USE_SEGGER_RTT=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm/nrf52840dk_nrf52840_v1/pre_dt_board.cmake
+++ b/boards/arm/nrf52840dk_nrf52840_v1/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf5340dk_nrf5340_v1/CMakeLists.txt
+++ b/boards/arm/nrf5340dk_nrf5340_v1/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+
+if ((CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS)
+    AND CONFIG_BOARD_ENABLE_CPUNET)
+zephyr_library()
+zephyr_library_sources(nrf5340_cpunet_reset.c)
+
+if (CONFIG_BUILD_WITH_TFM)
+  zephyr_library_include_directories(
+    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
+  )
+endif()
+
+endif()

--- a/boards/arm/nrf5340dk_nrf5340_v1/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340_v1/Kconfig
@@ -1,0 +1,58 @@
+# nRF5340 DK board configuration
+
+# Copyright (c) 2019 - 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF5340DK_NRF5340_V1_CPUAPP || BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+config BOARD_ENABLE_DCDC_APP
+	bool "Application MCU DCDC converter"
+	select SOC_DCDC_NRF53X_APP
+	default y
+
+config BOARD_ENABLE_DCDC_NET
+	bool "Network MCU DCDC converter"
+	select SOC_DCDC_NRF53X_NET
+	default y
+
+config BOARD_ENABLE_DCDC_HV
+	bool "High Voltage DCDC converter"
+	select SOC_DCDC_NRF53X_HV
+	default y
+
+config BOARD_ENABLE_CPUNET
+	bool "NRF53 Network MCU"
+	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
+		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
+	help
+	  This option enables releasing the Network 'force off' signal, which
+	  as a consequence will power up the Network MCU during system boot.
+	  Additionally, the option allocates GPIO pins that will be used by UARTE
+	  of the Network MCU.
+	  Note: GPIO pin allocation can only be configured by the secure Application
+	  MCU firmware, so when this option is used with the non-secure version of
+	  the board, the application needs to take into consideration, that the
+	  secure firmware image must already have configured GPIO allocation for the
+	  Network MCU.
+	default y if (BT || NRF_802154_SER_HOST)
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "nrf5340dk_nrf5340_v1_cpunet"
+	depends on BOARD_ENABLE_CPUNET
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc on the nRF5340_cpunet for
+	  Bluetooth applications.
+
+endif #  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+
+config DOMAIN_CPUAPP_BOARD
+	string
+	default "nrf5340dk_nrf5340_v1_cpuapp"
+	depends on BOARD_NRF5340DK_NRF5340_CPUNET
+	help
+	  The board which will be used for CPUAPP domain when creating a multi
+	  image application where one or more images should be located on
+	  another board.

--- a/boards/arm/nrf5340dk_nrf5340_v1/Kconfig.board
+++ b/boards/arm/nrf5340dk_nrf5340_v1/Kconfig.board
@@ -1,0 +1,18 @@
+# nRF5340 DK NRF5340 board configuration
+
+# Copyright (c) 2019-2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF5340_CPUAPP_QKAA
+
+config BOARD_NRF5340DK_NRF5340_V1_CPUAPP
+	bool "nRF5340 DK nRF5340 Application MCU"
+
+config BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+	bool "nRF5340 DK nRF5340 Application MCU non-secure"
+
+endif # SOC_NRF5340_CPUAPP_QKAA
+
+config BOARD_NRF5340DK_NRF5340_V1_CPUNET
+	bool "nRF5340 DK NRF5340 Network MCU"
+	depends on SOC_NRF5340_CPUNET_QKAA

--- a/boards/arm/nrf5340dk_nrf5340_v1/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340_v1/Kconfig.defconfig
@@ -1,0 +1,84 @@
+# nRF5340 DK nRF5340 board configuration
+
+# Copyright (c) 2019-2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if  BOARD_NRF5340DK_NRF5340_V1_CPUAPP || BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+config BOARD
+	default "nrf5340dk_nrf5340_v1_cpuapp" if BOARD_NRF5340DK_NRF5340_V1_CPUAPP || BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+# Code Partition:
+#
+# For the secure version of the board the firmware is linked at the beginning
+# of the flash, or into the code-partition defined in DT if it is intended to
+# be loaded by MCUboot. If the secure firmware is to be combined with a non-
+# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
+# be restricted to the size of its code partition.
+#
+# For the non-secure version of the board, the firmware
+# must be linked into the code-partition (non-secure) defined in DT, regardless.
+# Apply this configuration below by setting the Kconfig symbols used by
+# the linker according to the information extracted from DT partitions.
+
+# SRAM Partition:
+#
+# If the secure firmware is to be combined with a non-secure image
+# (TRUSTED_EXECUTION_SECURE=y), the secure FW image SRAM shall always
+# be restricted to the secure image SRAM partition (sram-secure-partition).
+# Otherwise (if TRUSTED_EXECUTION_SECURE is not set) the whole zephyr,sram
+# may be used by the image.
+#
+# For the non-secure version of the board, the firmware image SRAM is
+# always restricted to the allocated non-secure SRAM partition.
+#
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
+
+if BOARD_NRF5340DK_NRF5340_V1_CPUAPP && TRUSTED_EXECUTION_SECURE
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config SRAM_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
+
+endif # BOARD_NRF5340DK_NRF5340_V1_CPUAPP && TRUSTED_EXECUTION_SECURE
+
+if BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+config FLASH_LOAD_OFFSET
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+endif # BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+endif # BOARD_NRF5340DK_NRF5340_V1_CPUAPP || BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+config BOARD
+	default "nrf5340dk_nrf5340_v1_cpunet" if BOARD_NRF5340DK_NRF5340_V1_CPUNET
+
+config MBOX_NRFX_IPC
+	default MBOX
+
+if BOARD_NRF5340DK_NRF5340_V1_CPUAPP || BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+choice BT_HCI_BUS_TYPE
+	default BT_HCI_IPC if BT
+endchoice
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 4096 if BT_HCI_IPC
+
+endif #  BOARD_NRF5340DK_NRF5340_V1_CPUAPP || BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS
+
+if BOARD_NRF5340DK_NRF5340_V1_CPUNET
+
+config BT_CTLR
+	default y if BT
+
+endif # BOARD_NRF5340DK_NRF5340_V1_CPUNET

--- a/boards/arm/nrf5340dk_nrf5340_v1/board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340_v1/board.cmake
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS)
+  set(TFM_PUBLIC_KEY_FORMAT "full")
+endif()
+
+if(CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP OR CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS)
+board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
+endif()
+
+if(CONFIG_TFM_FLASH_MERGED_BINARY)
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+endif()
+
+if(CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUNET)
+board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
+endif()
+
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	i2c1_default: i2c1_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+		};
+	};
+
+	i2c1_sleep: i2c1_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 20)>,
+				<NRF_PSEL(UART_RTS, 0, 19)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 22)>,
+				<NRF_PSEL(UART_CTS, 0, 21)>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 20)>,
+				<NRF_PSEL(UART_RX, 0, 22)>,
+				<NRF_PSEL(UART_RTS, 0, 19)>,
+				<NRF_PSEL(UART_CTS, 0, 21)>;
+			low-power-enable;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			low-power-enable;
+		};
+	};
+
+	qspi_default: qspi_default {
+		group1 {
+			psels = <NRF_PSEL(QSPI_SCK, 0, 17)>,
+				<NRF_PSEL(QSPI_IO0, 0, 13)>,
+				<NRF_PSEL(QSPI_IO1, 0, 14)>,
+				<NRF_PSEL(QSPI_IO2, 0, 15)>,
+				<NRF_PSEL(QSPI_IO3, 0, 16)>,
+				<NRF_PSEL(QSPI_CSN, 0, 18)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+
+	qspi_sleep: qspi_sleep {
+		group1 {
+			psels = <NRF_PSEL(QSPI_SCK, 0, 17)>,
+				<NRF_PSEL(QSPI_IO0, 0, 13)>,
+				<NRF_PSEL(QSPI_IO1, 0, 14)>,
+				<NRF_PSEL(QSPI_IO2, 0, 15)>,
+				<NRF_PSEL(QSPI_IO3, 0, 16)>;
+			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
+			low-power-enable;
+			bias-pull-up;
+		};
+	};
+
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 1)>,
+				<NRF_PSEL(UART_RTS, 0, 11)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_CTS, 0, 10)>;
+			bias-pull-up;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 1)>,
+				<NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_RTS, 0, 11)>,
+				<NRF_PSEL(UART_CTS, 0, 10)>;
+			low-power-enable;
+		};
+	};
+
+	spi4_default: spi4_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+		};
+	};
+
+	spi4_sleep: spi4_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			low-power-enable;
+		};
+	};
+
+};

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpuapp_common.dtsi
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2019-2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "nrf5340_cpuapp_common-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+			label = "Green LED 0";
+		};
+		led1: led_1 {
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+			label = "Green LED 1";
+		};
+		led2: led_2 {
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			label = "Green LED 2";
+		};
+		led3: led_3 {
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 23 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		button1: button_1 {
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+		button2: button_2 {
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 3";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+		button3: button_3 {
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 4";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
+			   <1 0 &gpio0 5 0>,	/* A1 */
+			   <2 0 &gpio0 6 0>,	/* A2 */
+			   <3 0 &gpio0 7 0>,	/* A3 */
+			   <4 0 &gpio0 25 0>,	/* A4 */
+			   <5 0 &gpio0 26 0>,	/* A5 */
+			   <6 0 &gpio1 0 0>,	/* D0 */
+			   <7 0 &gpio1 1 0>,	/* D1 */
+			   <8 0 &gpio1 4 0>,	/* D2 */
+			   <9 0 &gpio1 5 0>,	/* D3 */
+			   <10 0 &gpio1 6 0>,	/* D4 */
+			   <11 0 &gpio1 7 0>,	/* D5 */
+			   <12 0 &gpio1 8 0>,	/* D6 */
+			   <13 0 &gpio1 9 0>,	/* D7 */
+			   <14 0 &gpio1 10 0>,	/* D8 */
+			   <15 0 &gpio1 11 0>,	/* D9 */
+			   <16 0 &gpio1 12 0>,	/* D10 */
+			   <17 0 &gpio1 13 0>,	/* D11 */
+			   <18 0 &gpio1 14 0>,	/* D12 */
+			   <19 0 &gpio1 15 0>,	/* D13 */
+			   <20 0 &gpio1 2 0>,	/* D14 */
+			   <21 0 &gpio1 3 0>;	/* D15 */
+	};
+
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc 0>,	/* A0 = P0.4 = AIN0 */
+				 <1 &adc 1>,	/* A1 = P0.5 = AIN1 */
+				 <2 &adc 2>,	/* A2 = P0.6 = AIN2 */
+				 <3 &adc 3>,	/* A3 = P0.7 = AIN3 */
+				 <4 &adc 4>,	/* A4 = P0.25 = AIN4 */
+				 <5 &adc 5>;	/* A5 = P0.26 = AIN5 */
+	};
+
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "okay";
+		uart {
+			gpios = <&gpio1 1 0>, <&gpio1 0 0>, <&gpio0 11 0>, <&gpio0 10 0>;
+		};
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		pwm-led0 = &pwm_led0;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
+		spi-flash0 = &mx25r64;
+	};
+};
+
+&adc {
+	status = "okay";
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&i2c1 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-1 = <&i2c1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&qspi {
+	status = "okay";
+	pinctrl-0 = <&qspi_default>;
+	pinctrl-1 = <&qspi_sleep>;
+	pinctrl-names = "default", "sleep";
+	mx25r64: mx25r6435f@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		/* MX25R64 supports only pp and pp4io */
+		writeoc = "pp4io";
+		/* MX25R64 supports all readoc options */
+		readoc = "read4io";
+		sck-frequency = <8000000>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};
+
+arduino_serial: &uart1 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_i2c: &i2c1 {};
+
+arduino_spi: &spi4 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi4_default>;
+	pinctrl-1 = <&spi4_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+		};
+		slot0_ns_partition: partition@50000 {
+			label = "image-0-nonsecure";
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+		};
+		slot1_ns_partition: partition@c0000 {
+			label = "image-1-nonsecure";
+		};
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 0x00008000>;
+		};
+	};
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};
+
+/ {
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_image: image@20000000 {
+			/* Zephyr image(s) memory */
+		};
+
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+		};
+
+		sram0_ns: image_ns@20040000 {
+			/* Non-Secure image memory */
+		};
+	};
+};
+
+/* Include partition configuration file */
+#include "nrf5340_cpuapp_partition_conf.dtsi"

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpuapp_partition_conf.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpuapp_partition_conf.dtsi
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Default Flash planning for nrf5340dk_nrf5340 CPUAPP (Application MCU).
+ *
+ * Zephyr build for nRF5340 with ARM TrustZone-M support,
+ * implies building Secure and Non-Secure Zephyr images.
+ *
+ * Secure image will be placed, by default, in flash0
+ * (or in slot0, if MCUboot is present).
+ * Secure image will use sram0 for system memory.
+ *
+ * Non-Secure image will be placed in slot0_ns, and use
+ * sram0_ns for system memory.
+ *
+ * Note that the Secure image only requires knowledge of
+ * the beginning of the Non-Secure image (not its size).
+ */
+
+&slot0_partition {
+	reg = <0x00010000 0x40000>;
+};
+
+&slot0_ns_partition {
+	reg = <0x00050000 0x30000>;
+};
+
+&slot1_partition {
+	reg = <0x00080000 0x40000>;
+};
+
+&slot1_ns_partition {
+	reg = <0x000c0000 0x30000>;
+};
+
+/* Default SRAM planning when building for nRF5340 with
+ * ARM TrustZone-M support
+ * - Lowest 256 kB SRAM allocated to Secure image (sram0_s)
+ * - Middle 192 kB allocated to Non-Secure image (sram0_ns)
+ * - Upper 64 kB SRAM allocated as Shared memory (sram0_shared)
+ *   (see nrf5340_shared_sram_planning_conf.dtsi)
+ */
+&sram0_image {
+	reg = <0x20000000 DT_SIZE_K(448)>;
+};
+
+&sram0_s {
+	reg = <0x20000000 0x40000>;
+};
+
+&sram0_ns {
+	reg = <0x20040000 0x30000>;
+};
+
+/* Include shared RAM configuration file */
+#include "nrf5340_shared_sram_planning_conf.dtsi"

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_cpunet_reset.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019-2021 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
+
+#include <soc.h>
+#include <hal/nrf_reset.h>
+
+LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
+
+#if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
+#include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h>
+#else
+#define DEBUG_SETUP()
+#endif
+
+static void remoteproc_mgr_config(void)
+{
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM)
+	/* Route Bluetooth Controller Debug Pins */
+	DEBUG_SETUP();
+#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM) */
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	/* Retain nRF5340 Network MCU in Secure domain (bus
+	 * accesses by Network MCU will have Secure attribute set).
+	 */
+	NRF_SPU->EXTDOMAIN[0].PERM = 1 << 4;
+#endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+}
+
+static int remoteproc_mgr_boot(void)
+{
+
+	/* Secure domain may configure permissions for the Network MCU. */
+	remoteproc_mgr_config();
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_SECURE)
+	/*
+	 * Building Zephyr with CONFIG_TRUSTED_EXECUTION_SECURE=y implies
+	 * building also a Non-Secure image. The Non-Secure image will, in
+	 * this case do the remainder of actions to properly configure and
+	 * boot the Network MCU.
+	 */
+
+	/* Release the Network MCU, 'Release force off signal' */
+	nrf_reset_network_force_off(NRF_RESET, false);
+
+	LOG_DBG("Network MCU released.");
+#endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */
+
+	return 0;
+}
+
+SYS_INIT(remoteproc_mgr_boot, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_shared_sram_planning_conf.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340_shared_sram_planning_conf.dtsi
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Default shared SRAM planning when building for nRF5340.
+ * This file is included by both nRF5340 CPUAPP (Application MCU)
+ * and nRF5340 CPUNET (Network MCU).
+ * - 64 kB SRAM allocated as Shared memory (sram0_shared)
+ * - Region defined after the image SRAM of Application MCU
+ */
+
+/ {
+	chosen {
+		/* shared memory reserved for the inter-processor communication */
+		zephyr,ipc_shm = &sram0_shared;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_shared: memory@20070000 {
+			/* SRAM allocated to shared memory */
+			reg = <0x20070000 0x10000>;
+		};
+	};
+};

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp.dts
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp.dts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf5340_cpuapp_qkaa.dtsi>
+#include "nrf5340_cpuapp_common.dtsi"
+
+/ {
+	model = "Nordic NRF5340 DK NRF5340 Application";
+	compatible = "nordic,nrf5340-dk-nrf5340-cpuapp";
+
+	chosen {
+		zephyr,sram = &sram0_image;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,sram-secure-partition = &sram0_s;
+		zephyr,sram-non-secure-partition = &sram0_ns;
+	};
+};

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp.yaml
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp.yaml
@@ -1,0 +1,22 @@
+identifier: nrf5340dk_nrf5340_v1_cpuapp
+name: NRF5340-DK-NRF5340-application-MCU
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 448
+flash: 1024
+supported:
+  - gpio
+  - i2c
+  - i2s
+  - pwm
+  - watchdog
+  - usb_cdc
+  - usb_device
+  - netif:openthread
+  - gpio
+  - spi
+vendor: nordic

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_defconfig
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF53X=y
+CONFIG_SOC_NRF5340_CPUAPP_QKAA=y
+CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable TrustZone-M
+CONFIG_ARM_TRUSTZONE_M=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_ns.dts
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_ns.dts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf5340_cpuappns_qkaa.dtsi>
+#include "nrf5340_cpuapp_common.dtsi"
+
+/ {
+	model = "Nordic NRF5340 DK NRF5340 Application";
+	compatible = "nordic,nrf5340-dk-nrf5340-cpuapp";
+
+	chosen {
+		zephyr,sram = &sram0_ns;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_ns_partition;
+	};
+};

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_ns.yaml
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_ns.yaml
@@ -1,0 +1,20 @@
+identifier: nrf5340dk_nrf5340_v1_cpuapp_ns
+name: NRF5340-DK-NRF5340-application-MCU-Non-Secure
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 192
+flash: 192
+supported:
+  - i2c
+  - pwm
+  - watchdog
+  - usb_cdc
+  - usb_device
+  - netif:openthread
+  - gpio
+  - spi
+vendor: nordic

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_ns_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpuapp_ns_defconfig
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF53X=y
+CONFIG_SOC_NRF5340_CPUAPP_QKAA=y
+CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUAPP_NS=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable TrustZone-M
+CONFIG_ARM_TRUSTZONE_M=y
+
+# This Board implies building Non-Secure firmware
+CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet-pinctrl.dtsi
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 1)>,
+				<NRF_PSEL(UART_RTS, 0, 11)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_CTS, 0, 10)>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 1)>,
+				<NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_RTS, 0, 11)>,
+				<NRF_PSEL(UART_CTS, 0, 10)>;
+			low-power-enable;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+		};
+	};
+
+	i2c0_sleep: i2c0_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			low-power-enable;
+		};
+	};
+
+	spi0_default: spi0_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+		};
+	};
+
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			low-power-enable;
+		};
+	};
+
+};

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet.dts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf5340_cpunet_qkaa.dtsi>
+#include "nrf5340dk_nrf5340_v1_cpunet-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "Nordic NRF5340 DK NRF5340 Network";
+	compatible = "nordic,nrf5340-dk-nrf5340-cpunet";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-ipc = &ipc0;
+		nordic,802154-spinel-ipc = &ipc0;
+		zephyr,sram = &sram1;
+		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+			label = "Green LED 0";
+		};
+		led1: led_1 {
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+			label = "Green LED 1";
+		};
+		led2: led_2 {
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			label = "Green LED 2";
+		};
+		led3: led_3 {
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			label = "Green LED 3";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 23 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		button1: button_1 {
+			gpios = <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+		button2: button_2 {
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 3";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+		button3: button_3 {
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 4";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
+			   <1 0 &gpio0 5 0>,	/* A1 */
+			   <2 0 &gpio0 6 0>,	/* A2 */
+			   <3 0 &gpio0 7 0>,	/* A3 */
+			   <4 0 &gpio0 25 0>,	/* A4 */
+			   <5 0 &gpio0 26 0>,	/* A5 */
+			   <6 0 &gpio1 0 0>,	/* D0 */
+			   <7 0 &gpio1 1 0>,	/* D1 */
+			   <8 0 &gpio1 4 0>,	/* D2 */
+			   <9 0 &gpio1 5 0>,	/* D3 */
+			   <10 0 &gpio1 6 0>,	/* D4 */
+			   <11 0 &gpio1 7 0>,	/* D5 */
+			   <12 0 &gpio1 8 0>,	/* D6 */
+			   <13 0 &gpio1 9 0>,	/* D7 */
+			   <14 0 &gpio1 10 0>,	/* D8 */
+			   <15 0 &gpio1 11 0>,	/* D9 */
+			   <16 0 &gpio1 12 0>,	/* D10 */
+			   <17 0 &gpio1 13 0>,	/* D11 */
+			   <18 0 &gpio1 14 0>,	/* D12 */
+			   <19 0 &gpio1 15 0>,	/* D13 */
+			   <20 0 &gpio1 2 0>,	/* D14 */
+			   <21 0 &gpio1 3 0>;	/* D15 */
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
+	};
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_serial: &uart0{};
+
+arduino_i2c: &i2c0 {
+	compatible = "nordic,nrf-twim";
+	/* Cannot be used together with uart0. */
+	/* status = "okay"; */
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-1 = <&i2c0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_spi: &spi0 {
+	compatible = "nordic,nrf-spim";
+	/* Cannot be used together with uart0. */
+	/* status = "okay"; */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&flash1 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0xc000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x17000>;
+		};
+		slot1_partition: partition@23000 {
+			label = "image-1";
+			reg = <0x00023000 0x17000>;
+		};
+		storage_partition: partition@3a000 {
+			label = "storage";
+			reg = <0x0003a000 0x6000>;
+		};
+	};
+};
+
+&ieee802154 {
+	status = "okay";
+};
+
+/* Include shared RAM configuration file */
+#include "nrf5340_shared_sram_planning_conf.dtsi"

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet.yaml
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet.yaml
@@ -1,0 +1,14 @@
+identifier: nrf5340dk_nrf5340_v1_cpunet
+name: NRF5340-DK-NRF5340-network-MCU
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 64
+flash: 256
+supported:
+  - watchdog
+  - gpio
+vendor: nordic

--- a/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet_defconfig
+++ b/boards/arm/nrf5340dk_nrf5340_v1/nrf5340dk_nrf5340_v1_cpunet_defconfig
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF53X=y
+CONFIG_SOC_NRF5340_CPUNET_QKAA=y
+CONFIG_BOARD_NRF5340DK_NRF5340_V1_CPUNET=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm/nrf5340dk_nrf5340_v1/pre_dt_board.cmake
+++ b/boards/arm/nrf5340dk_nrf5340_v1/pre_dt_board.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+# - /reserved-memory/image@20000000 & /reserved-memory/image_s@20000000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160dk_nrf9160_v1/CMakeLists.txt
+++ b/boards/arm/nrf9160dk_nrf9160_v1/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(nrf52840_reset.c)

--- a/boards/arm/nrf9160dk_nrf9160_v1/Kconfig.board
+++ b/boards/arm/nrf9160dk_nrf9160_v1/Kconfig.board
@@ -1,0 +1,14 @@
+# nRF9160 DK NRF9160 board configuration
+
+# Copyright (c) 2018-2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9160_SICA
+
+config BOARD_NRF9160DK_NRF9160_V1
+	bool "nRF9160 DK NRF9160"
+
+config BOARD_NRF9160DK_NRF9160_V1_NS
+	bool "nRF9160 DK NRF9160 non-secure"
+
+endif # SOC_NRF9160_SICA

--- a/boards/arm/nrf9160dk_nrf9160_v1/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160_v1/Kconfig.defconfig
@@ -1,0 +1,47 @@
+# nRF9160 DK NRF9160 board configuration
+
+# Copyright (c) 2018-2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF9160DK_NRF9160_V1 || BOARD_NRF9160DK_NRF9160_V1_NS
+
+config BOARD
+	default "nrf9160dk_nrf9160_v1"
+
+# For the secure version of the board the firmware is linked at the beginning
+# of the flash, or into the code-partition defined in DT if it is intended to
+# be loaded by MCUboot. If the secure firmware is to be combined with a non-
+# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
+# be restricted to the size of its code partition.
+# For the non-secure version of the board, the firmware
+# must be linked into the code-partition (non-secure) defined in DT, regardless.
+# Apply this configuration below by setting the Kconfig symbols used by
+# the linker according to the information extracted from DT partitions.
+
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+	depends on BOARD_NRF9160DK_NRF9160_V1 && TRUSTED_EXECUTION_SECURE
+
+if BOARD_NRF9160DK_NRF9160_V1_NS
+
+config FLASH_LOAD_OFFSET
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+endif # BOARD_NRF9160DK_NRF9160_V1_NS
+
+config BT_HCI_VS
+	default y if BT
+
+config BT_WAIT_NOP
+	default BT && $(dt_nodelabel_enabled,nrf52840_reset)
+
+config I2C
+	default $(dt_compat_on_bus,$(DT_COMPAT_NXP_PCAL6408A),i2c)
+
+endif # BOARD_NRF9160DK_NRF9160_V1 || BOARD_NRF9160DK_NRF9160_V1_NS

--- a/boards/arm/nrf9160dk_nrf9160_v1/board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160_v1/board.cmake
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_NRF9160DK_NRF9160_V1_NS)
+  set(TFM_PUBLIC_KEY_FORMAT "full")
+endif()
+
+if(CONFIG_TFM_FLASH_MERGED_BINARY)
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+endif()
+
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/bindings/nordic,nrf9160dk-nrf52840-interface.yaml
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/bindings/nordic,nrf9160dk-nrf52840-interface.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This file is replicated in nrf9160dk_nrf9160 and nrf9160dk_nrf52840.
+#       Any changes should be done in both instances.
+
+description: |
+    nRF9160 DK GPIO interface between nRF9160 and nRF52840
+
+    This interface can be used for inter-SoC communication on the DK.
+    The connections are as follows:
+
+    | nRF9160 |                            |    nRF52840    |
+    |   P0.17 | -- nRF interface line 0 -- | P0.17          |
+    |   P0.18 | -- nRF interface line 1 -- | P0.20          |
+    |   P0.19 | -- nRF interface line 2 -- | P0.15          |
+    |   P0.21 | -- nRF interface line 3 -- | P0.22          |
+    |   P0.22 | -- nRF interface line 4 -- | P1.04          |
+    |   P0.23 | -- nRF interface line 5 -- | P1.02          |
+    |   COEX0 | -- nRF interface line 6 -- | P1.13          |
+    |   COEX1 | -- nRF interface line 7 -- | P1.11          |
+    |   COEX2 | -- nRF interface line 8 -- | P1.15          |
+    |   P0.24 | -- nRF interface line 9 -- | P0.18 (nRESET) | (in v0.14.0 or later)
+
+    Before particular lines of this interface can be used, the corresponding
+    analog switches that control the routing of involved nRF9160 pins must be
+    configured to provide the optional routing (i.e. to nRF52840). To achieve
+    this, set the status of respective devicetree nodes in the firmware for
+    the nrf9160dk_nrf52840 board to "okay":
+    - `nrf_interface_pins_0_2_routing` to enable lines 0-2
+    - `nrf_interface_pins_3_5_routing` to enable lines 3-5
+    - `nrf_interface_pins_6_8_routing` to enable lines 6-8
+    - `nrf_interface_pin_9_routing` to enable line 9 (this line is only
+      available in nRF9160 DK v0.14.0 or later)
+
+    NOTE: In nRF9160 DK revisions earlier than v0.14.0, when the above signals
+          from nRF9160 are routed to nRF52840, they are not available on the DK
+          connectors.
+
+compatible: "nordic,nrf9160dk-nrf52840-interface"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/bindings/nordic,nrf9160dk-nrf52840-reset.yaml
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/bindings/nordic,nrf9160dk-nrf52840-reset.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This file is replicated in nrf9160dk_nrf9160 and nrf9160dk_nrf52840.
+#       Any changes should be done in both instances.
+
+description: GPIO used to reset nRF52840 on nRF9160 DK
+
+compatible: "nordic,nrf9160dk-nrf52840-reset"
+
+include: base.yaml
+
+properties:
+  status:
+    required: true
+
+  gpios:
+    type: phandle-array
+    required: true
+    description: |
+      GPIO to use as nRF52840 reset line: output in nRF9160, input in nRF52840.

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_buttons_on_io_expander.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_buttons_on_io_expander.dtsi
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* NOTE: this feature is only available in nRF9160 DK v0.14.0 or later. */
+
+&pcal6408a {
+	status = "okay";
+};
+
+&button0 {
+	gpios = <&pcal6408a 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};
+
+&button1 {
+	gpios = <&pcal6408a 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};
+
+&button2 {
+	gpios = <&pcal6408a 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};
+
+&button3 {
+	gpios = <&pcal6408a 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_leds_on_io_expander.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_leds_on_io_expander.dtsi
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* NOTE: this feature is only available in nRF9160 DK v0.14.0 or later. */
+
+&pcal6408a {
+	status = "okay";
+};
+
+&led0 {
+	gpios = <&pcal6408a 4 GPIO_ACTIVE_HIGH>;
+};
+
+&led1 {
+	gpios = <&pcal6408a 5 GPIO_ACTIVE_HIGH>;
+};
+
+&led2 {
+	gpios = <&pcal6408a 6 GPIO_ACTIVE_HIGH>;
+};
+
+&led3 {
+	gpios = <&pcal6408a 7 GPIO_ACTIVE_HIGH>;
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_nrf52840_reset_on_if5.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_nrf52840_reset_on_if5.dtsi
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&nrf52840_reset {
+	status = "okay";
+	gpios = <&interface_to_nrf52840 5 GPIO_ACTIVE_HIGH>;
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_nrf52840_reset_on_if9.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_nrf52840_reset_on_if9.dtsi
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* NOTE: this feature is only available in nRF9160 DK v0.14.0 or later. */
+
+&nrf52840_reset {
+	status = "okay";
+	gpios = <&interface_to_nrf52840 9 GPIO_ACTIVE_LOW>;
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_uart1_on_if0_3.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/dts/nrf9160dk_uart1_on_if0_3.dtsi
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart1_default_alt: uart1_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 18)>,
+				<NRF_PSEL(UART_RX, 0, 17)>,
+				<NRF_PSEL(UART_RTS, 0, 21)>,
+				<NRF_PSEL(UART_CTS, 0, 19)>;
+		};
+	};
+
+	uart1_sleep_alt: uart1_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 18)>,
+				<NRF_PSEL(UART_RX, 0, 17)>,
+				<NRF_PSEL(UART_RTS, 0, 21)>,
+				<NRF_PSEL(UART_CTS, 0, 19)>;
+			low-power-enable;
+		};
+	};
+
+};
+
+&uart1 {
+	status = "okay";
+	pinctrl-0 = <&uart1_default_alt>;
+	pinctrl-1 = <&uart1_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf52840_reset.c
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf52840_reset.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+
+#define RESET_NODE DT_NODELABEL(nrf52840_reset)
+
+#if DT_NODE_HAS_STATUS(RESET_NODE, okay)
+
+#define RESET_GPIO_CTRL  DT_GPIO_CTLR(RESET_NODE, gpios)
+#define RESET_GPIO_PIN   DT_GPIO_PIN(RESET_NODE, gpios)
+#define RESET_GPIO_FLAGS DT_GPIO_FLAGS(RESET_NODE, gpios)
+
+int bt_hci_transport_setup(const struct device *h4)
+{
+	int err;
+	char c;
+	const struct device *const port = DEVICE_DT_GET(RESET_GPIO_CTRL);
+
+	if (!device_is_ready(port)) {
+		return -EIO;
+	}
+
+	/* Configure pin as output and initialize it to inactive state. */
+	err = gpio_pin_configure(port, RESET_GPIO_PIN,
+				 RESET_GPIO_FLAGS | GPIO_OUTPUT_INACTIVE);
+	if (err) {
+		return err;
+	}
+
+	/* Reset the nRF52840 and let it wait until the pin is inactive again
+	 * before running to main to ensure that it won't send any data until
+	 * the H4 device is setup and ready to receive.
+	 */
+	err = gpio_pin_set(port, RESET_GPIO_PIN, 1);
+	if (err) {
+		return err;
+	}
+
+	/* Wait for the nRF52840 peripheral to stop sending data.
+	 *
+	 * It is critical (!) to wait here, so that all bytes
+	 * on the lines are received and drained correctly.
+	 */
+	k_sleep(K_MSEC(10));
+
+	/* Drain bytes */
+	while (h4 && uart_fifo_read(h4, &c, 1)) {
+		continue;
+	}
+
+	/* We are ready, let the nRF52840 run to main */
+	err = gpio_pin_set(port, RESET_GPIO_PIN, 0);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+#endif /* DT_NODE_HAS_STATUS(RESET_NODE, okay) */

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1.dts
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1.dts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf9160_sica.dtsi>
+#include "nrf9160dk_nrf9160_v1_common.dtsi"
+
+/ {
+	chosen {
+		zephyr,sram = &sram0_s;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,sram-secure-partition = &sram0_s;
+		zephyr,sram-non-secure-partition = &sram0_ns;
+	};
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1.yaml
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1.yaml
@@ -1,0 +1,22 @@
+identifier: nrf9160dk_nrf9160_v1
+name: nRF9160-DK-NRF9160
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 88
+flash: 1024
+supported:
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
+  - gpio
+  - i2c
+  - pwm
+  - spi
+  - watchdog
+  - counter
+vendor: nordic

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_0_14_0.overlay
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_0_14_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9160dk_nrf9160_v1_common_0_14_0.dtsi"

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_common-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_common-pinctrl.dtsi
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 29)>,
+				<NRF_PSEL(UART_RTS, 0, 27)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 28)>,
+				<NRF_PSEL(UART_CTS, 0, 26)>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 29)>,
+				<NRF_PSEL(UART_RX, 0, 28)>,
+				<NRF_PSEL(UART_RTS, 0, 27)>,
+				<NRF_PSEL(UART_CTS, 0, 26)>;
+			low-power-enable;
+		};
+	};
+
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RTS, 0, 14)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 0)>,
+				<NRF_PSEL(UART_CTS, 0, 15)>;
+			bias-pull-up;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>,
+				<NRF_PSEL(UART_RTS, 0, 14)>,
+				<NRF_PSEL(UART_CTS, 0, 15)>;
+			low-power-enable;
+		};
+	};
+
+	uart2_default: uart2_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 24)>,
+				<NRF_PSEL(UART_RX, 0, 23)>;
+		};
+	};
+
+	uart2_sleep: uart2_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 24)>,
+				<NRF_PSEL(UART_RX, 0, 23)>;
+			low-power-enable;
+		};
+	};
+
+	i2c2_default: i2c2_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
+				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+		};
+	};
+
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
+				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+			low-power-enable;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 2)>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 2)>;
+			low-power-enable;
+		};
+	};
+
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
+				<NRF_PSEL(SPIM_MISO, 0, 12)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 11)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
+				<NRF_PSEL(SPIM_MISO, 0, 12)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 11)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_common.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_common.dtsi
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "nrf9160dk_nrf9160_v1_common-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "Nordic nRF9160 DK NRF9160";
+	compatible = "nordic,nrf9160-dk-nrf9160";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 2 0>;
+			label = "Green LED 1";
+		};
+		led1: led_1 {
+			gpios = <&gpio0 3 0>;
+			label = "Green LED 2";
+		};
+		led2: led_2 {
+			gpios = <&gpio0 4 0>;
+			label = "Green LED 3";
+		};
+		led3: led_3 {
+			gpios = <&gpio0 5 0>;
+			label = "Green LED 4";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	buttons {
+		/*
+		 * Unlike most DK boards, we do not actually have 4 buttons
+		 * on nRF9160 DK. Instead, we have 2 buttons and 2 switches.
+		 * Treat the switches as buttons anyway, for convenience.
+		 * This makes life easier for software that wants to deal with
+		 * the usual "4 buttons per DK board" convention.
+		 */
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		button1: button_1 {
+			gpios = <&gpio0 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+		button2: button_2 {
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Switch 1";
+			zephyr,code = <INPUT_KEY_2>;
+		};
+		button3: button_3 {
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Switch 2";
+			zephyr,code = <INPUT_KEY_3>;
+		};
+	};
+
+	interface_to_nrf52840: gpio-interface {
+		compatible = "nordic,nrf9160dk-nrf52840-interface";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xf 0>;
+		gpio-map-pass-thru = <0 0xffffffff>;
+		gpio-map = <0 0 &gpio0 17 0>,
+			   <1 0 &gpio0 18 0>,
+			   <2 0 &gpio0 19 0>,
+			   <3 0 &gpio0 21 0>,
+			   <4 0 &gpio0 22 0>,
+			   <5 0 &gpio0 23 0>;
+			   /* 6: COEX0 */
+			   /* 7: COEX1 */
+			   /* 8: COEX2 */
+	};
+
+	nrf52840_reset: gpio-reset {
+		compatible = "nordic,nrf9160dk-nrf52840-reset";
+		status = "disabled";
+		/*
+		 * This line is specified as active high for compatibility
+		 * with the previously used Kconfig-based configuration.
+		 */
+		gpios = <&interface_to_nrf52840 5 GPIO_ACTIVE_HIGH>;
+	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 14 0>,	/* A0 */
+			   <1 0 &gpio0 15 0>,	/* A1 */
+			   <2 0 &gpio0 16 0>,	/* A2 */
+			   <3 0 &gpio0 17 0>,	/* A3 */
+			   <4 0 &gpio0 18 0>,	/* A4 */
+			   <5 0 &gpio0 19 0>,	/* A5 */
+			   <6 0 &gpio0 0 0>,	/* D0 */
+			   <7 0 &gpio0 1 0>,	/* D1 */
+			   <8 0 &gpio0 2 0>,	/* D2 */
+			   <9 0 &gpio0 3 0>,	/* D3 */
+			   <10 0 &gpio0 4 0>,	/* D4 */
+			   <11 0 &gpio0 5 0>,	/* D5 */
+			   <12 0 &gpio0 6 0>,	/* D6 */
+			   <13 0 &gpio0 7 0>,	/* D7 */
+			   <14 0 &gpio0 8 0>,	/* D8 */
+			   <15 0 &gpio0 9 0>,	/* D9 */
+			   <16 0 &gpio0 10 0>,	/* D10 */
+			   <17 0 &gpio0 11 0>,	/* D11 */
+			   <18 0 &gpio0 12 0>,	/* D12 */
+			   <19 0 &gpio0 13 0>,	/* D13 */
+			   <20 0 &gpio0 30 0>,	/* D14 */
+			   <21 0 &gpio0 31 0>;	/* D15 */
+	};
+
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc 1>,	/* A0 = P0.14 = AIN1 */
+				 <1 &adc 2>,	/* A1 = P0.15 = AIN2 */
+				 <2 &adc 3>,	/* A2 = P0.16 = AIN3 */
+				 <3 &adc 4>,	/* A3 = P0.17 = AIN4 */
+				 <4 &adc 5>,	/* A4 = P0.18 = AIN5 */
+				 <5 &adc 6>;	/* A5 = P0.19 = AIN6 */
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		pwm-led0 = &pwm_led0;
+		sw0 = &button0;
+		sw1 = &button1;
+		sw2 = &button2;
+		sw3 = &button3;
+		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
+	};
+};
+
+&adc {
+	status = "okay";
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_serial: &uart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&uart2 {
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-1 = <&uart2_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_i2c: &i2c2 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c2_default>;
+	pinctrl-1 = <&i2c2_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_spi: &spi3 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x10000>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+		};
+		slot0_ns_partition: partition@50000 {
+			label = "image-0-nonsecure";
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+		};
+		slot1_ns_partition: partition@c0000 {
+			label = "image-1-nonsecure";
+		};
+		/* 0xf0000 to 0xf7fff reserved for TF-M partitions */
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 0x00008000>;
+		};
+	};
+};
+
+/ {
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+		};
+
+		sram0_modem: image_modem@20016000 {
+			/* Modem (shared) memory */
+		};
+
+		sram0_ns: image_ns@20020000 {
+			/* Non-Secure image memory */
+		};
+	};
+};
+
+/* Include partition configuration file */
+#include "nrf9160dk_nrf9160_partition_conf.dtsi"

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_common_0_14_0.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_common_0_14_0.dtsi
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		spi-flash0 = &mx25r64;
+	};
+};
+
+&interface_to_nrf52840 {
+	gpio-map = <0 0 &gpio0 17 0>,
+		   <1 0 &gpio0 18 0>,
+		   <2 0 &gpio0 19 0>,
+		   <3 0 &gpio0 21 0>,
+		   <4 0 &gpio0 22 0>,
+		   <5 0 &gpio0 23 0>,
+		   /* 6: COEX0 */
+		   /* 7: COEX1 */
+		   /* 8: COEX2 */
+		   <9 0 &gpio0 24 0>;
+};
+
+&nrf52840_reset {
+	gpios = <&interface_to_nrf52840 9 GPIO_ACTIVE_LOW>;
+};
+
+&i2c2 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	pcal6408a: pcal6408a@20 {
+		compatible = "nxp,pcal6408a";
+		status = "disabled";
+		reg = <0x20>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <8>;
+		int-gpios = <&gpio0 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+};
+
+&arduino_spi {
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>, /* D10 */
+		   <&gpio0 25 GPIO_ACTIVE_LOW>;
+	mx25r64: mx25r6435f@1 {
+		compatible = "jedec,spi-nor";
+		status = "disabled";
+		reg = <1>;
+		spi-max-frequency = <8000000>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_defconfig
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_defconfig
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF91X=y
+CONFIG_SOC_NRF9160_SICA=y
+CONFIG_BOARD_NRF9160DK_NRF9160_V1=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable TrustZone-M
+CONFIG_ARM_TRUSTZONE_M=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns.dts
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns.dts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf9160ns_sica.dtsi>
+#include "nrf9160dk_nrf9160_v1_common.dtsi"
+
+/ {
+	chosen {
+		zephyr,flash = &flash0;
+		zephyr,sram = &sram0_ns;
+		zephyr,code-partition = &slot0_ns_partition;
+	};
+};
+
+/* Disable UART1, because it is used by default in TF-M */
+&uart1 {
+	status = "disabled";
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns.yaml
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns.yaml
@@ -1,0 +1,21 @@
+identifier: nrf9160dk_nrf9160_v1_ns
+name: nRF9160-DK-NRF9160-Non-Secure
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 128
+flash: 192
+supported:
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
+  - i2c
+  - pwm
+  - watchdog
+  - netif:modem
+  - gpio
+vendor: nordic

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns_0_14_0.overlay
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns_0_14_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9160dk_nrf9160_v1_common_0_14_0.dtsi"

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns_defconfig
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_ns_defconfig
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF91X=y
+CONFIG_SOC_NRF9160_SICA=y
+CONFIG_BOARD_NRF9160DK_NRF9160_V1_NS=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable TrustZone-M
+CONFIG_ARM_TRUSTZONE_M=y
+
+# This Board implies building Non-Secure firmware
+CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable uart driver
+CONFIG_SERIAL=y
+
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_partition_conf.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160_v1/nrf9160dk_nrf9160_v1_partition_conf.dtsi
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018-2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Default Flash planning for nRF9160dk_nrf9160.
+ *
+ * Zephyr build for nRF9160 with ARM TrustZone-M support,
+ * implies building Secure and Non-Secure Zephyr images.
+ *
+ * Secure image will be placed, by default, in flash0
+ * (or in slot0, if MCUboot is present).
+ * Secure image will use sram0 for system memory.
+ *
+ * Non-Secure image will be placed in slot0_ns, and use
+ * sram0_ns for system memory.
+ *
+ * Note that the Secure image only requires knowledge of
+ * the beginning of the Non-Secure image (not its size).
+ */
+
+&slot0_partition {
+	reg = <0x00010000 0x40000>;
+};
+
+&slot0_ns_partition {
+	reg = <0x00050000 0x30000>;
+};
+
+&slot1_partition {
+	reg = <0x00080000 0x40000>;
+};
+
+&slot1_ns_partition {
+	reg = <0x000c0000 0x30000>;
+};
+
+/* Default SRAM planning when building for nRF9160 with
+ * ARM TrustZone-M support
+ * - Lowest 88 kB SRAM allocated to Secure image (sram0_s).
+ * - 40 kB SRAM reserved for and used by the modem library
+ *   (sram0_modem). This memory is Non-Secure.
+ * - Upper 128 kB allocated to Non-Secure image (sram0_ns).
+ *   When building with TF-M, both sram0_modem and sram0_ns
+ *   are allocated to the Non-Secure image.
+ */
+
+&sram0_s {
+	reg = <0x20000000 DT_SIZE_K(88)>;
+};
+
+&sram0_modem {
+	reg = <0x20016000 DT_SIZE_K(40)>;
+};
+
+&sram0_ns {
+	reg = <0x20020000 DT_SIZE_K(128)>;
+};

--- a/boards/arm/nrf9160dk_nrf9160_v1/pre_dt_board.cmake
+++ b/boards/arm/nrf9160dk_nrf9160_v1/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf9160dk_nrf9160_v1/revision.cmake
+++ b/boards/arm/nrf9160dk_nrf9160_v1/revision.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+board_check_revision(
+  FORMAT MAJOR.MINOR.PATCH
+  DEFAULT_REVISION 0.14.0
+  VALID_REVISIONS 0.7.0 0.14.0
+)

--- a/soc/arm/CMakeLists.txt
+++ b/soc/arm/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(nordic_nrf)

--- a/soc/arm/nordic_nrf/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/CMakeLists.txt
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+add_subdirectory(${SOC_SERIES})
+add_subdirectory(common)
+
+zephyr_library_sources(
+  validate_base_addresses.c
+  validate_enabled_instances.c
+  )
+
+if(CONFIG_SOC_HAS_TIMING_FUNCTIONS AND NOT CONFIG_BOARD_HAS_TIMING_FUNCTIONS)
+  if(CONFIG_TIMING_FUNCTIONS)
+    # Use nRF-specific timing calculations only if DWT is not present
+    if(NOT CONFIG_CORTEX_M_DWT)
+      zephyr_library_sources(timing.c)
+    endif()
+  endif()
+endif()
+
+if(CONFIG_BUILD_WITH_TFM)
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DHAL_NORDIC_PATH=${ZEPHYR_HAL_NORDIC_MODULE_DIR}
+    )
+
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DZEPHYR_BASE=${ZEPHYR_BASE}
+    )
+
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_NS_STORAGE=${CONFIG_TFM_NRF_NS_STORAGE}
+    )
+endif()

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -1,0 +1,175 @@
+# Nordic Semiconductor nRFx MCU line
+
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_FAMILY_NRF
+	select SOC_COMPATIBLE_NRF
+	select PLATFORM_SPECIFIC_INIT
+	bool
+
+if SOC_FAMILY_NRF
+config SOC_FAMILY
+	string
+	default "nordic_nrf"
+
+rsource "common/Kconfig.peripherals"
+rsource "*/Kconfig.soc"
+
+config NRF_SOC_SECURE_SUPPORTED
+	def_bool !TRUSTED_EXECUTION_NONSECURE || (BUILD_WITH_TFM && TFM_PARTITION_PLATFORM)
+	depends on !SOC_SERIES_NRF54HX
+	help
+	  Hidden function to indicate that that the soc_secure functions are
+	  available.
+	  The functions are always available when not in non-secure.
+	  For non-secure the functions must redirect to secure services exposed
+	  by the secure firmware.
+
+config BUILD_WITH_TFM
+	default y if TRUSTED_EXECUTION_NONSECURE
+	help
+	  By default, if we build for a Non-Secure version of the board,
+	  enable building with TF-M as the Secure Execution Environment.
+
+if BUILD_WITH_TFM
+
+config TFM_FLASH_MERGED_BINARY
+	default y
+	help
+	  By default, if we build with TF-M, instruct build system to
+	  flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+
+config TFM_LOG_LEVEL_SILENCE
+	default y if !$(dt_nodelabel_has_prop,uart1,pinctrl-names)
+	help
+	  Disable TF-M secure output if the uart1 node has not assigned GPIO
+	  pins using pinctrl.
+
+config TFM_NRF_NS_STORAGE
+	bool "TF-M non-secure storage partition"
+	default y
+
+endif # BUILD_WITH_TFM
+
+
+config NRF_MPU_FLASH_REGION_SIZE
+	hex
+	default 0x1000
+	depends on HAS_HW_NRF_MPU
+	help
+	  FLASH region size for the NRF_MPU peripheral.
+
+config NRF_BPROT_FLASH_REGION_SIZE
+	hex
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	depends on HAS_HW_NRF_BPROT
+	help
+	  FLASH region size for the NRF_BPROT peripheral (nRF52).
+
+config NRF_ACL_FLASH_REGION_SIZE
+	hex
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	depends on HAS_HW_NRF_ACL
+	help
+	  FLASH region size for the NRF_ACL peripheral.
+
+config NFCT_PINS_AS_GPIOS
+	bool "[DEPRECATED] NFCT pins as GPIOs"
+	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_NFCT))
+	select DEPRECATED
+	help
+	  Two pins are usually reserved for NFC in SoCs that implement the
+	  NFCT peripheral. This option switches them to normal GPIO mode.
+	  HW enabling happens once in the device lifetime, during the first
+	  system startup. Disabling this option will not switch back these
+	  pins to NFCT mode. Doing this requires UICR erase prior to
+	  flashing device using the image which has this option disabled.
+
+	  NFC pins in nRF52 series: P0.09 and P0.10
+	  NFC pins in nRF5340: P0.02 and P0.03
+
+	  This option is deprecated, please use devicetree to configure NFCT
+	  pins as GPIOS like this:
+
+	  &uicr {
+	      nfct-pins-as-gpios;
+	  };
+
+choice NRF_APPROTECT_HANDLING
+	bool "APPROTECT handling"
+	depends on SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET || \
+		   (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE) || \
+		   SOC_SERIES_NRF91X
+	default NRF_APPROTECT_USE_UICR
+	help
+	  Specifies how the SystemInit() function should handle the APPROTECT
+	  mechanism.
+
+config NRF_APPROTECT_USE_UICR
+	bool "Use UICR"
+	help
+	  When this option is selected, the SystemInit() function loads the
+	  firmware branch state of the APPROTECT mechanism from UICR, so if
+	  UICR->APPROTECT is disabled, CTRLAP->APPROTECT will be disabled.
+
+config NRF_APPROTECT_LOCK
+	bool "Lock"
+	help
+	  When this option is selected, the SystemInit() function locks
+	  the firmware branch of the APPROTECT mechanism, preventing it
+	  from being opened.
+
+config NRF_APPROTECT_USER_HANDLING
+	bool "Allow user handling"
+	depends on !SOC_SERIES_NRF52X
+	help
+	  When this option is selected, the SystemInit() function does not
+	  touch the APPROTECT mechanism, allowing the user code to handle it
+	  at later stages, for example, to implement authenticated debug.
+
+endchoice
+
+choice NRF_SECURE_APPROTECT_HANDLING
+	bool "Secure APPROTECT handling"
+	depends on (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE)
+	default NRF_SECURE_APPROTECT_USE_UICR
+	help
+	  Specifies how the SystemInit() function should handle the secure
+	  APPROTECT mechanism.
+
+config NRF_SECURE_APPROTECT_USE_UICR
+	bool "Use UICR"
+	help
+	  When this option is selected, the SystemInit() function loads the
+	  firmware branch state of the secure APPROTECT mechanism from UICR,
+	  so if UICR->SECUREAPPROTECT is disabled, CTRLAP->SECUREAPPROTECT
+	  will be disabled.
+
+config NRF_SECURE_APPROTECT_LOCK
+	bool "Lock"
+	help
+	  When this option is selected, the SystemInit() function locks the
+	  firmware branch of the secure APPROTECT mechanism, preventing it
+	  from being opened.
+
+config NRF_SECURE_APPROTECT_USER_HANDLING
+	bool "Allow user handling"
+	depends on !SOC_SERIES_NRF52X
+	help
+	  When this option is selected, the SystemInit() function does not
+	  touch the secure APPROTECT mechanism, allowing the user code to
+	  handle it at later stages, for example, to implement authenticated
+	  debug.
+
+endchoice
+
+config NRF_TRACE_PORT
+	bool "nRF TPIU"
+	depends on !SOC_SERIES_NRF51X
+	help
+	  Enable this option to initialize the TPIU (Trace Port Interface
+	  Unit) for tracing using a hardware probe. If disabled, the trace
+	  pins will be used as GPIO.
+
+endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -1,0 +1,45 @@
+# Nordic Semiconductor nRFx MCU line
+
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_NRF
+
+rsource "*/Kconfig.defconfig.series"
+
+# If the kernel has timer support, enable clock control
+if SYS_CLOCK_EXISTS
+
+config CLOCK_CONTROL
+	default y if !SOC_SERIES_NRF54HX
+
+endif # SYS_CLOCK_EXISTS
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 1000000 if NRF_GRTC_TIMER
+	default 32768
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 128 if !TICKLESS_KERNEL
+	default 10000  if NRF_GRTC_TIMER
+	default 32768
+
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y if !QEMU_TARGET
+
+config BUILD_OUTPUT_HEX
+	default y
+
+if !CORTEX_M_DWT && NRF_RTC_TIMER
+config SOC_HAS_TIMING_FUNCTIONS
+	default y
+endif
+
+config GPIO
+	default y
+	depends on SPI
+
+config UART_USE_RUNTIME_CONFIGURE
+	default n
+
+endif # SOC_FAMILY_NRF

--- a/soc/arm/nordic_nrf/Kconfig.soc
+++ b/soc/arm/nordic_nrf/Kconfig.soc
@@ -1,0 +1,6 @@
+# Nordic Semiconductor nRFx MCU line
+
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig.series"

--- a/soc/arm/nordic_nrf/common/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/common/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_NRF soc_nrf_common.S)
+zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
+
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")
+
+if (CONFIG_TFM_PARTITION_PLATFORM)
+  zephyr_library_sources(soc_secure.c)
+  zephyr_library_include_directories(
+    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
+  )
+endif()

--- a/soc/arm/nordic_nrf/common/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/common/Kconfig.peripherals
@@ -1,0 +1,490 @@
+# Nordic Semiconductor nRFx MCU peripherals list.
+
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config HAS_HW_NRF_ACL
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_ACL))
+
+config HAS_HW_NRF_ADC
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_ADC))
+
+config HAS_HW_NRF_BPROT
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_BPROT))
+
+config HAS_HW_NRF_CC310
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_ARM_CRYPTOCELL_310))
+
+config HAS_HW_NRF_CC312
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_ARM_CRYPTOCELL_312))
+
+config HAS_HW_NRF_CCM
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_CCM))
+
+config HAS_HW_NRF_CCM_LFLEN_8BIT
+	def_bool $(dt_nodelabel_bool_prop,ccm,length-field-length-8-bits)
+
+config HAS_HW_NRF_CCM_HEADERMASK
+	def_bool $(dt_nodelabel_bool_prop,ccm,headermask-supported)
+
+config HAS_HW_NRF_CLOCK
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_CLOCK))
+
+config HAS_HW_NRF_COMP
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_COMP))
+
+config HAS_HW_NRF_CTRLAP
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_CTRLAPPERI))
+
+config HAS_HW_NRF_DCNF
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_DCNF))
+
+config HAS_HW_NRF_DPPIC
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_DPPIC))
+
+config HAS_HW_NRF_ECB
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_ECB))
+
+config HAS_HW_NRF_EGU0
+	def_bool $(dt_nodelabel_enabled_with_compat,egu0,$(DT_COMPAT_NORDIC_NRF_EGU))
+
+config HAS_HW_NRF_EGU1
+	def_bool $(dt_nodelabel_enabled_with_compat,egu1,$(DT_COMPAT_NORDIC_NRF_EGU))
+
+config HAS_HW_NRF_EGU2
+	def_bool $(dt_nodelabel_enabled_with_compat,egu2,$(DT_COMPAT_NORDIC_NRF_EGU))
+
+config HAS_HW_NRF_EGU3
+	def_bool $(dt_nodelabel_enabled_with_compat,egu3,$(DT_COMPAT_NORDIC_NRF_EGU))
+
+config HAS_HW_NRF_EGU4
+	def_bool $(dt_nodelabel_enabled_with_compat,egu4,$(DT_COMPAT_NORDIC_NRF_EGU))
+
+config HAS_HW_NRF_EGU5
+	def_bool $(dt_nodelabel_enabled_with_compat,egu5,$(DT_COMPAT_NORDIC_NRF_EGU))
+
+config HAS_HW_NRF_GPIO0
+	def_bool $(dt_nodelabel_enabled_with_compat,gpio0,$(DT_COMPAT_NORDIC_NRF_GPIO))
+
+config HAS_HW_NRF_GPIO1
+	def_bool $(dt_nodelabel_enabled_with_compat,gpio1,$(DT_COMPAT_NORDIC_NRF_GPIO))
+
+config HAS_HW_NRF_GPIOTE0
+	def_bool $(dt_nodelabel_enabled_with_compat,gpiote0,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
+
+config HAS_HW_NRF_GPIOTE1
+	def_bool $(dt_nodelabel_enabled_with_compat,gpiote1,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
+
+config HAS_HW_NRF_GPIOTE20
+	def_bool $(dt_nodelabel_enabled_with_compat,gpiote20,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
+
+config HAS_HW_NRF_GPIOTE30
+	def_bool $(dt_nodelabel_enabled_with_compat,gpiote30,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
+
+config HAS_HW_NRF_GPIOTE130
+	def_bool $(dt_nodelabel_enabled_with_compat,gpiote130,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
+
+config HAS_HW_NRF_GPIOTE131
+	def_bool $(dt_nodelabel_enabled_with_compat,gpiote131,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
+
+config HAS_HW_NRF_I2S0
+	def_bool $(dt_nodelabel_enabled_with_compat,i2s0,$(DT_COMPAT_NORDIC_NRF_I2S))
+
+config HAS_HW_NRF_I2S20
+	def_bool $(dt_nodelabel_enabled_with_compat,i2s20,$(DT_COMPAT_NORDIC_NRF_I2S))
+
+config HAS_HW_NRF_IPC
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_IPC))
+
+config HAS_HW_NRF_KMU
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_KMU))
+
+config HAS_HW_NRF_LPCOMP
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_LPCOMP))
+
+config HAS_HW_NRF_MPU
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_MPU))
+
+config HAS_HW_NRF_MUTEX
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_MUTEX))
+
+config HAS_HW_NRF_MWU
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_MWU))
+
+config HAS_HW_NRF_NFCT
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_NFCT))
+
+config HAS_HW_NRF_NVMC_PE
+	def_bool $(dt_nodelabel_bool_prop,flash_controller,partial-erase)
+
+config HAS_HW_NRF_OSCILLATORS
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_OSCILLATORS))
+
+config HAS_HW_NRF_PDM
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_PDM))
+
+config HAS_HW_NRF_POWER
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_POWER))
+
+config HAS_HW_NRF_PPI
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_PPI))
+
+config HAS_HW_NRF_PWM0
+	def_bool $(dt_nodelabel_enabled_with_compat,pwm0,$(DT_COMPAT_NORDIC_NRF_PWM))
+
+config HAS_HW_NRF_PWM1
+	def_bool $(dt_nodelabel_enabled_with_compat,pwm1,$(DT_COMPAT_NORDIC_NRF_PWM))
+
+config HAS_HW_NRF_PWM2
+	def_bool $(dt_nodelabel_enabled_with_compat,pwm2,$(DT_COMPAT_NORDIC_NRF_PWM))
+
+config HAS_HW_NRF_PWM3
+	def_bool $(dt_nodelabel_enabled_with_compat,pwm3,$(DT_COMPAT_NORDIC_NRF_PWM))
+
+config HAS_HW_NRF_QDEC0
+	def_bool $(dt_nodelabel_enabled_with_compat,qdec0,$(DT_COMPAT_NORDIC_NRF_QDEC))
+
+config HAS_HW_NRF_QDEC1
+	def_bool $(dt_nodelabel_enabled_with_compat,qdec1,$(DT_COMPAT_NORDIC_NRF_QDEC))
+
+config HAS_HW_NRF_QDEC20
+	def_bool $(dt_nodelabel_enabled_with_compat,qdec20,$(DT_COMPAT_NORDIC_NRF_QDEC))
+
+config HAS_HW_NRF_QDEC21
+	def_bool $(dt_nodelabel_enabled_with_compat,qdec21,$(DT_COMPAT_NORDIC_NRF_QDEC))
+
+config HAS_HW_NRF_QDEC130
+	def_bool $(dt_nodelabel_enabled_with_compat,qdec130,$(DT_COMPAT_NORDIC_NRF_QDEC))
+
+config HAS_HW_NRF_QDEC131
+	def_bool $(dt_nodelabel_enabled_with_compat,qdec131,$(DT_COMPAT_NORDIC_NRF_QDEC))
+
+config HAS_HW_NRF_QSPI
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_QSPI))
+
+config HAS_HW_NRF_RADIO_BLE_2M
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-2mbps-supported)
+
+config HAS_HW_NRF_RADIO_BLE_CODED
+	def_bool $(dt_nodelabel_bool_prop,radio,ble-coded-phy-supported)
+
+config HAS_HW_NRF_RADIO_DFE
+	def_bool $(dt_nodelabel_bool_prop,radio,dfe-supported)
+
+config HAS_HW_NRF_RADIO_IEEE802154
+	def_bool $(dt_nodelabel_bool_prop,radio,ieee802154-supported)
+
+config HAS_HW_NRF_RADIO_TX_PWR_HIGH
+	def_bool $(dt_nodelabel_bool_prop,radio,tx-high-power-supported)
+
+config HAS_HW_NRF_REGULATORS
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_REGULATORS))
+
+config HAS_HW_NRF_RESET
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_RESET))
+
+config HAS_HW_NRF_RNG
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_RNG))
+
+config HAS_HW_NRF_RTC0
+	def_bool $(dt_nodelabel_enabled_with_compat,rtc0,$(DT_COMPAT_NORDIC_NRF_RTC))
+
+config HAS_HW_NRF_RTC1
+	def_bool $(dt_nodelabel_enabled_with_compat,rtc1,$(DT_COMPAT_NORDIC_NRF_RTC))
+
+config HAS_HW_NRF_RTC2
+	def_bool $(dt_nodelabel_enabled_with_compat,rtc2,$(DT_COMPAT_NORDIC_NRF_RTC))
+
+config HAS_HW_NRF_SAADC
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_SAADC))
+
+config HAS_HW_NRF_SPI0
+	def_bool $(dt_nodelabel_enabled_with_compat,spi0,$(DT_COMPAT_NORDIC_NRF_SPI))
+
+config HAS_HW_NRF_SPI1
+	def_bool $(dt_nodelabel_enabled_with_compat,spi1,$(DT_COMPAT_NORDIC_NRF_SPI))
+
+config HAS_HW_NRF_SPI2
+	def_bool $(dt_nodelabel_enabled_with_compat,spi2,$(DT_COMPAT_NORDIC_NRF_SPI))
+
+config HAS_HW_NRF_SPIM0
+	def_bool $(dt_nodelabel_enabled_with_compat,spi0,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM1
+	def_bool $(dt_nodelabel_enabled_with_compat,spi1,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM2
+	def_bool $(dt_nodelabel_enabled_with_compat,spi2,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM3
+	def_bool $(dt_nodelabel_enabled_with_compat,spi3,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM4
+	def_bool $(dt_nodelabel_enabled_with_compat,spi4,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM00
+	def_bool $(dt_nodelabel_enabled_with_compat,spi00,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM20
+	def_bool $(dt_nodelabel_enabled_with_compat,spi20,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM21
+	def_bool $(dt_nodelabel_enabled_with_compat,spi21,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM22
+	def_bool $(dt_nodelabel_enabled_with_compat,spi22,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM30
+	def_bool $(dt_nodelabel_enabled_with_compat,spi30,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM120
+	def_bool $(dt_nodelabel_enabled_with_compat,spi120,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM121
+	def_bool $(dt_nodelabel_enabled_with_compat,spi121,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM130
+	def_bool $(dt_nodelabel_enabled_with_compat,spi130,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM131
+	def_bool $(dt_nodelabel_enabled_with_compat,spi131,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM132
+	def_bool $(dt_nodelabel_enabled_with_compat,spi132,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM133
+	def_bool $(dt_nodelabel_enabled_with_compat,spi133,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM134
+	def_bool $(dt_nodelabel_enabled_with_compat,spi134,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM135
+	def_bool $(dt_nodelabel_enabled_with_compat,spi135,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM136
+	def_bool $(dt_nodelabel_enabled_with_compat,spi136,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIM137
+	def_bool $(dt_nodelabel_enabled_with_compat,spi137,$(DT_COMPAT_NORDIC_NRF_SPIM))
+
+config HAS_HW_NRF_SPIS0
+	def_bool $(dt_nodelabel_enabled_with_compat,spi0,$(DT_COMPAT_NORDIC_NRF_SPIS))
+
+config HAS_HW_NRF_SPIS1
+	def_bool $(dt_nodelabel_enabled_with_compat,spi1,$(DT_COMPAT_NORDIC_NRF_SPIS))
+
+config HAS_HW_NRF_SPIS2
+	def_bool $(dt_nodelabel_enabled_with_compat,spi2,$(DT_COMPAT_NORDIC_NRF_SPIS))
+
+config HAS_HW_NRF_SPIS3
+	def_bool $(dt_nodelabel_enabled_with_compat,spi3,$(DT_COMPAT_NORDIC_NRF_SPIS))
+
+config HAS_HW_NRF_SPU
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_SPU))
+
+config HAS_HW_NRF_SWI0
+	def_bool $(dt_nodelabel_enabled_with_compat,swi0,$(DT_COMPAT_NORDIC_NRF_SWI))
+
+config HAS_HW_NRF_SWI1
+	def_bool $(dt_nodelabel_enabled_with_compat,swi1,$(DT_COMPAT_NORDIC_NRF_SWI))
+
+config HAS_HW_NRF_SWI2
+	def_bool $(dt_nodelabel_enabled_with_compat,swi2,$(DT_COMPAT_NORDIC_NRF_SWI))
+
+config HAS_HW_NRF_SWI3
+	def_bool $(dt_nodelabel_enabled_with_compat,swi3,$(DT_COMPAT_NORDIC_NRF_SWI))
+
+config HAS_HW_NRF_SWI4
+	def_bool $(dt_nodelabel_enabled_with_compat,swi4,$(DT_COMPAT_NORDIC_NRF_SWI))
+
+config HAS_HW_NRF_SWI5
+	def_bool $(dt_nodelabel_enabled_with_compat,swi5,$(DT_COMPAT_NORDIC_NRF_SWI))
+
+config HAS_HW_NRF_TEMP
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_TEMP))
+
+config HAS_HW_NRF_TIMER0
+	def_bool $(dt_nodelabel_enabled_with_compat,timer0,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER1
+	def_bool $(dt_nodelabel_enabled_with_compat,timer1,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER2
+	def_bool $(dt_nodelabel_enabled_with_compat,timer2,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER3
+	def_bool $(dt_nodelabel_enabled_with_compat,timer3,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER4
+	def_bool $(dt_nodelabel_enabled_with_compat,timer4,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER00
+	def_bool $(dt_nodelabel_enabled_with_compat,timer00,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER10
+	def_bool $(dt_nodelabel_enabled_with_compat,timer10,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER20
+	def_bool $(dt_nodelabel_enabled_with_compat,timer20,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER21
+	def_bool $(dt_nodelabel_enabled_with_compat,timer21,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER22
+	def_bool $(dt_nodelabel_enabled_with_compat,timer22,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER23
+	def_bool $(dt_nodelabel_enabled_with_compat,timer23,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TIMER24
+	def_bool $(dt_nodelabel_enabled_with_compat,timer24,$(DT_COMPAT_NORDIC_NRF_TIMER))
+
+config HAS_HW_NRF_TWI0
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c0,$(DT_COMPAT_NORDIC_NRF_TWI))
+
+config HAS_HW_NRF_TWI1
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c1,$(DT_COMPAT_NORDIC_NRF_TWI))
+
+config HAS_HW_NRF_TWIM0
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c0,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM1
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c1,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM2
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c2,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM3
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c3,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM20
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c20,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM21
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c21,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM22
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c22,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM30
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c30,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM120
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c120,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM130
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c130,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM131
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c131,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM132
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c132,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM133
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c133,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM134
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c134,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM135
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c135,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM136
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c136,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIM137
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c137,$(DT_COMPAT_NORDIC_NRF_TWIM))
+
+config HAS_HW_NRF_TWIS0
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c0,$(DT_COMPAT_NORDIC_NRF_TWIS))
+
+config HAS_HW_NRF_TWIS1
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c1,$(DT_COMPAT_NORDIC_NRF_TWIS))
+
+config HAS_HW_NRF_TWIS2
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c2,$(DT_COMPAT_NORDIC_NRF_TWIS))
+
+config HAS_HW_NRF_TWIS3
+	def_bool $(dt_nodelabel_enabled_with_compat,i2c3,$(DT_COMPAT_NORDIC_NRF_TWIS))
+
+config HAS_HW_NRF_UART0
+	def_bool $(dt_nodelabel_enabled_with_compat,uart0,$(DT_COMPAT_NORDIC_NRF_UART))
+
+config HAS_HW_NRF_UARTE0
+	def_bool $(dt_nodelabel_enabled_with_compat,uart0,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE1
+	def_bool $(dt_nodelabel_enabled_with_compat,uart1,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE2
+	def_bool $(dt_nodelabel_enabled_with_compat,uart2,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE3
+	def_bool $(dt_nodelabel_enabled_with_compat,uart3,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE00
+	def_bool $(dt_nodelabel_enabled_with_compat,uart00,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE20
+	def_bool $(dt_nodelabel_enabled_with_compat,uart20,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE21
+	def_bool $(dt_nodelabel_enabled_with_compat,uart21,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE22
+	def_bool $(dt_nodelabel_enabled_with_compat,uart22,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE30
+	def_bool $(dt_nodelabel_enabled_with_compat,uart30,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE120
+	def_bool $(dt_nodelabel_enabled_with_compat,uart120,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE130
+	def_bool $(dt_nodelabel_enabled_with_compat,uart130,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE131
+	def_bool $(dt_nodelabel_enabled_with_compat,uart131,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE132
+	def_bool $(dt_nodelabel_enabled_with_compat,uart132,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE133
+	def_bool $(dt_nodelabel_enabled_with_compat,uart133,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE134
+	def_bool $(dt_nodelabel_enabled_with_compat,uart134,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE135
+	def_bool $(dt_nodelabel_enabled_with_compat,uart135,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE136
+	def_bool $(dt_nodelabel_enabled_with_compat,uart136,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE137
+	def_bool $(dt_nodelabel_enabled_with_compat,uart137,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_USBD
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_USBD))
+
+config HAS_HW_NRF_USBREG
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_USBREG))
+
+config HAS_HW_NRF_VMC
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_VMC))
+
+config HAS_HW_NRF_WDT0
+	def_bool $(dt_nodelabel_enabled_with_compat,wdt0,$(DT_COMPAT_NORDIC_NRF_WDT))
+
+config HAS_HW_NRF_WDT1
+	def_bool $(dt_nodelabel_enabled_with_compat,wdt1,$(DT_COMPAT_NORDIC_NRF_WDT))
+
+config HAS_HW_NRF_WDT30
+	def_bool $(dt_nodelabel_enabled_with_compat,wdt30,$(DT_COMPAT_NORDIC_NRF_WDT))
+
+config HAS_HW_NRF_WDT31
+	def_bool $(dt_nodelabel_enabled_with_compat,wdt31,$(DT_COMPAT_NORDIC_NRF_WDT))
+
+config HAS_HW_NRF_WDT130
+	def_bool $(dt_nodelabel_enabled_with_compat,wdt130,$(DT_COMPAT_NORDIC_NRF_WDT))

--- a/soc/arm/nordic_nrf/common/pinctrl_soc.h
+++ b/soc/arm/nordic_nrf/common/pinctrl_soc.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * nRF SoC specific helpers for pinctrl driver
+ */
+
+#ifndef ZEPHYR_SOC_ARM_NORDIC_NRF_COMMON_PINCTRL_SOC_H_
+#define ZEPHYR_SOC_ARM_NORDIC_NRF_COMMON_PINCTRL_SOC_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/dt-bindings/pinctrl/nrf-pinctrl.h>
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+/** Type for nRF pin. */
+typedef uint32_t pinctrl_soc_pin_t;
+
+/**
+ * @brief Utility macro to initialize each pin.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)			       \
+	(DT_PROP_BY_IDX(node_id, prop, idx) |				       \
+	 ((NRF_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << NRF_PULL_POS) |\
+	 ((NRF_PULL_UP * DT_PROP(node_id, bias_pull_up)) << NRF_PULL_POS) |    \
+	 (DT_PROP(node_id, nordic_drive_mode) << NRF_DRIVE_POS) |	       \
+	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
+	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS)		       \
+	),
+
+/**
+ * @brief Utility macro to initialize state pins contained in a given property.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name describing state pins.
+ */
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			       \
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
+				DT_FOREACH_PROP_ELEM, psels,		       \
+				Z_PINCTRL_STATE_PIN_INIT)}
+
+/**
+ * @brief Utility macro to obtain pin function.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_FUN(pincfg) (((pincfg) >> NRF_FUN_POS) & NRF_FUN_MSK)
+
+/**
+ * @brief Utility macro to obtain pin inversion flag.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_INVERT(pincfg) (((pincfg) >> NRF_INVERT_POS) & NRF_INVERT_MSK)
+
+/**
+ * @brief Utility macro to obtain pin low power flag.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_LP(pincfg) (((pincfg) >> NRF_LP_POS) & NRF_LP_MSK)
+
+/**
+ * @brief Utility macro to obtain pin drive mode.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_DRIVE(pincfg) (((pincfg) >> NRF_DRIVE_POS) & NRF_DRIVE_MSK)
+
+/**
+ * @brief Utility macro to obtain pin pull configuration.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_PULL(pincfg) (((pincfg) >> NRF_PULL_POS) & NRF_PULL_MSK)
+
+/**
+ * @brief Utility macro to obtain port and pin combination.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_PIN(pincfg) (((pincfg) >> NRF_PIN_POS) & NRF_PIN_MSK)
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_SOC_ARM_NORDIC_NRF_COMMON_PINCTRL_SOC_H_ */

--- a/soc/arm/nordic_nrf/common/poweroff.c
+++ b/soc/arm/nordic_nrf/common/poweroff.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+
+#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
+#include <hal/nrf_power.h>
+#else
+#include <hal/nrf_regulators.h>
+#endif
+
+void z_sys_poweroff(void)
+{
+#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
+	nrf_power_system_off(NRF_POWER);
+#else
+	nrf_regulators_system_off(NRF_REGULATORS);
+#endif
+
+	CODE_UNREACHABLE;
+}

--- a/soc/arm/nordic_nrf/common/soc_nrf_common.S
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.S
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for Nordic Semiconductor nRFxx family processors
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+
+_ASM_FILE_PROLOGUE
+
+GTEXT(SystemInit)
+GTEXT(z_arm_platform_init)
+
+SECTION_FUNC(TEXT, z_arm_platform_init)
+
+	/* Implement z_arm_platform_init() directly in ASM,
+	 * and ensure no stack access is performed until
+	 * we jump to SystemInit().
+	 */
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	ldr r0, =SystemInit
+	bx r0
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	b SystemInit
+#else
+#error "Unsupported architecture"
+#endif
+	/* Return occurs via SystemInit */

--- a/soc/arm/nordic_nrf/common/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file Common soc.h include for Nordic nRF5 SoCs.
+ */
+
+#ifndef _ZEPHYR_SOC_ARM_NORDIC_NRF_SOC_NRF_COMMON_H_
+#define _ZEPHYR_SOC_ARM_NORDIC_NRF_SOC_NRF_COMMON_H_
+
+#ifndef _ASMLANGUAGE
+#include <nrfx.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/toolchain.h>
+
+/**
+ * @brief Get a PSEL value out of a foo-gpios or foo-pin devicetree property
+ *
+ * Many Nordic bindings have 'foo-pin' properties to specify a pin
+ * configuration as a PSEL value directly instead of using a 'foo-gpios'
+ * <&gpioX Y flags> style controller phandle + GPIO specifier.
+ *
+ * It would be better to use 'foo-gpios' properties instead. This type
+ * of property is more in line with the recommended DT encoding for GPIOs.
+ *
+ * To allow for a smooth migration from 'foo-pin' to 'foo-gpios', this
+ * helper macro can be used to get a PSEL value out of the devicetree
+ * using whichever one of 'foo-gpios' or 'foo-pin' is in the DTS.
+ *
+ * Note that you can also use:
+ *
+ *   - NRF_DT_PSEL_CHECK_*() to check the property configuration at build time
+ *   - NRF_DT_GPIOS_TO_PSEL() if you only have a 'foo-gpios'
+ *
+ * @param node_id node identifier
+ * @param psel_prop lowercase-and-underscores old-style 'foo-pin' property
+ * @param gpios_prop new-style 'foo-gpios' property
+ * @param default_val the value returned if neither is set
+ * @return PSEL register value taken from psel_prop or gpios_prop, whichever
+ *         is present in the DTS. If gpios_prop is present, it is converted
+ *         to a PSEL register value first.
+ */
+#define NRF_DT_PSEL(node_id, psel_prop, gpios_prop, default_val)	\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, psel_prop),		\
+		    (DT_PROP(node_id, psel_prop)),			\
+		    (COND_CODE_1(					\
+			    DT_NODE_HAS_PROP(node_id, gpios_prop),	\
+			    (NRF_DT_GPIOS_TO_PSEL(node_id,		\
+						  gpios_prop)),		\
+			    (default_val))))
+
+/**
+ * Error out the build if the devicetree node with identifier
+ * 'node_id' has both a legacy psel-style property and a gpios
+ * property.
+ *
+ * Otherwise, do nothing.
+ *
+ * @param node_id node identifier
+ * @param psel_prop lowercase-and-underscores PSEL style property
+ * @param psel_prop_name human-readable string name of psel_prop
+ * @param gpios_prop lowercase-and-underscores foo-gpios style property
+ * @param gpio_prop_name human-readable string name of gpios_prop
+ */
+#define NRF_DT_PSEL_CHECK_NOT_BOTH(node_id, psel_prop, psel_prop_name,	\
+				   gpios_prop, gpios_prop_name)		\
+	BUILD_ASSERT(							\
+		!(DT_NODE_HAS_PROP(node_id, psel_prop) &&		\
+		  DT_NODE_HAS_PROP(node_id, gpios_prop)),		\
+		"Devicetree node " DT_NODE_PATH(node_id)		\
+		" has both of the " psel_prop_name			\
+		" and " gpios_prop_name					\
+		" properties set; you must remove one. "		\
+		"Note: you can use /delete-property/ to delete properties.")
+
+/**
+ * Like NRF_DT_PSEL_CHECK_NOT_BOTH, but instead checks that exactly one
+ * of the properties is set.
+ */
+#define NRF_DT_PSEL_CHECK_EXACTLY_ONE(node_id,				\
+				      psel_prop, psel_prop_name,	\
+				      gpios_prop, gpios_prop_name)	\
+	BUILD_ASSERT(							\
+		(DT_NODE_HAS_PROP(node_id, psel_prop) ^			\
+		 DT_NODE_HAS_PROP(node_id, gpios_prop)),		\
+		"Devicetree node " DT_NODE_PATH(node_id)		\
+		" must have exactly one of the " psel_prop_name		\
+		" and " gpios_prop_name					\
+		" properties set. "					\
+		"Note: you can use /delete-property/ to delete properties.")
+
+/**
+ * @brief Convert a devicetree GPIO phandle+specifier to PSEL value
+ *
+ * Various peripherals in nRF SoCs have pin select registers, which
+ * usually have PSEL in their names. The low bits of these registers
+ * generally look like this in the register map description:
+ *
+ *     Bit number     5 4 3 2 1 0
+ *     ID             B A A A A A
+ *
+ *     ID  Field  Value    Description
+ *     A   PIN    [0..31]  Pin number
+ *     B   PORT   [0..1]   Port number
+ *
+ * Examples:
+ *
+ * - pin P0.4 has "PSEL value" 4 (B=0 and A=4)
+ * - pin P1.5 has "PSEL value" 37 (B=1 and A=5)
+ *
+ * This macro converts a devicetree GPIO phandle array value
+ * "<&gpioX pin ...>" to a "PSEL value".
+ *
+ * Note: in Nordic SoC devicetrees, "gpio0" means P0, and "gpio1"
+ * means P1. This is encoded in the "port" property of each GPIO node.
+ *
+ * Examples:
+ *
+ *     foo: my-node {
+ *             tx-gpios = <&gpio0 4 ...>;
+ *             rx-gpios = <&gpio0 5 ...>, <&gpio1 5 ...>;
+ *     };
+ *
+ *     NRF_DT_GPIOS_TO_PSEL_BY_IDX(DT_NODELABEL(foo), tx_gpios, 0) // 0 + 4 = 4
+ *     NRF_DT_GPIOS_TO_PSEL_BY_IDX(DT_NODELABEL(foo), rx_gpios, 1) // 32 + 5 = 37
+ */
+#define NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, idx)			\
+	((DT_PROP_BY_PHANDLE_IDX(node_id, prop, idx, port) << 5) |	\
+	 (DT_GPIO_PIN_BY_IDX(node_id, prop, idx) & 0x1F))
+
+
+/**
+ * @brief Equivalent to NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, 0)
+ */
+#define NRF_DT_GPIOS_TO_PSEL(node_id, prop)			\
+	NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, 0)
+
+/**
+ * If the node has the property, expands to
+ * NRF_DT_GPIOS_TO_PSEL(node_id, prop). The default_value argument is
+ * not expanded in this case.
+ *
+ * Otherwise, expands to default_value.
+ */
+#define NRF_DT_GPIOS_TO_PSEL_OR(node_id, prop, default_value)	\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop),		\
+		    (NRF_DT_GPIOS_TO_PSEL(node_id, prop)),	\
+		    (default_value))
+
+/**
+ * @brief Convert a devicetree GPIO phandle+specifier to GPIOTE instance number.
+ *
+ * Some of nRF SoCs may have more instances of GPIOTE.
+ * To handle this, we use the "gpiote-instance" property of the GPIO node.
+ *
+ * This macro converts a devicetree GPIO phandle array value
+ * "<&gpioX pin ...>" to a GPIOTE instance number.
+ *
+ * Examples:
+ *
+ *     &gpiote0 {
+ *             instance = <0>;
+ *     };
+ *
+ *     &gpiote20 {
+ *             instance = <20>;
+ *     };
+ *
+ *     &gpio0 {
+ *             gpiote-instance = <&gpiote0>;
+ *     }
+ *
+ *     &gpio1 {
+ *             gpiote-instance = <&gpiote20>;
+ *     }
+ *
+ *     foo: my-node {
+ *             tx-gpios = <&gpio0 4 ...>;
+ *             rx-gpios = <&gpio0 5 ...>, <&gpio1 5 ...>;
+ *     };
+ *
+ *     NRF_DT_GPIOTE_INST_BY_IDX(DT_NODELABEL(foo), tx_gpios, 0) // = 0
+ *     NRF_DT_GPIOTE_INST_BY_IDX(DT_NODELABEL(foo), rx_gpios, 1) // = 20
+ */
+#define NRF_DT_GPIOTE_INST_BY_IDX(node_id, prop, idx)			\
+	DT_PROP(DT_PHANDLE(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx),	\
+			   gpiote_instance),				\
+		instance)
+
+/**
+ * @brief Equivalent to NRF_DT_GPIOTE_INST_BY_IDX(node_id, prop, 0)
+ */
+#define NRF_DT_GPIOTE_INST(node_id, prop)				\
+	NRF_DT_GPIOTE_INST_BY_IDX(node_id, prop, 0)
+
+/**
+ * Error out the build if 'prop' is set on node 'node_id' and
+ * DT_GPIO_CTLR(node_id, prop) is not an SoC GPIO controller,
+ * i.e. a node with compatible "nordic,nrf-gpio".
+ *
+ * Otherwise, do nothing.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores PSEL style property
+ * @param prop_name human-readable string name for 'prop'
+ */
+#define NRF_DT_CHECK_GPIO_CTLR_IS_SOC(node_id, prop, prop_name)		\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop),			\
+		   (BUILD_ASSERT(DT_NODE_HAS_COMPAT(			\
+					 DT_GPIO_CTLR(node_id, prop),	\
+					 nordic_nrf_gpio),		\
+				 "Devicetree node "			\
+				 DT_NODE_PATH(node_id)			\
+				 " property " prop_name			\
+				 " must refer to a GPIO controller "	\
+				 "with compatible nordic,nrf-gpio; "	\
+				 "got "					\
+				 DT_NODE_PATH(DT_GPIO_CTLR(node_id,	\
+							   prop))	\
+				 ", which does not have this "		\
+				 "compatible")),			\
+		    (BUILD_ASSERT(1,					\
+				  "NRF_DT_CHECK_GPIO_CTLR_IS_SOC: OK")))
+/* Note: allow a trailing ";" either way */
+
+/**
+ * Error out the build if CONFIG_PM_DEVICE=y and pinctrl-1 state (sleep) is not
+ * defined.
+ *
+ * @param node_id node identifier
+ */
+#define NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(node_id)			       \
+	BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE) ||			       \
+		     DT_PINCTRL_HAS_NAME(node_id, sleep),		       \
+		     DT_NODE_PATH(node_id) " defined without sleep state")
+
+#endif /* !_ASMLANGUAGE */
+
+#endif

--- a/soc/arm/nordic_nrf/common/soc_secure.c
+++ b/soc/arm/nordic_nrf/common/soc_secure.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc_secure.h>
+#include <errno.h>
+
+#include "nrf.h"
+
+#include "tfm_platform_api.h"
+#include "tfm_ioctl_api.h"
+
+#if NRF_GPIO_HAS_SEL
+void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
+{
+	uint32_t result;
+	enum tfm_platform_err_t err;
+
+	err = tfm_platform_gpio_pin_mcu_select(pin_number, mcu, &result);
+	__ASSERT(err == TFM_PLATFORM_ERR_SUCCESS, "TFM platform error (%d)", err);
+	__ASSERT(result == 0, "GPIO service error (%d)", result);
+}
+#endif /* NRF_GPIO_HAS_SEL */
+
+int soc_secure_mem_read(void *dst, void *src, size_t len)
+{
+	enum tfm_platform_err_t status;
+	uint32_t result;
+
+	status = tfm_platform_mem_read(dst, (uintptr_t)src, len, &result);
+
+	switch (status) {
+	case TFM_PLATFORM_ERR_INVALID_PARAM:
+		return -EINVAL;
+	case TFM_PLATFORM_ERR_NOT_SUPPORTED:
+		return -ENOTSUP;
+	case TFM_PLATFORM_ERR_SUCCESS:
+		if (result == 0) {
+			return 0;
+		}
+		/* Fallthrough */
+	default:
+		return -EPERM;
+	}
+}

--- a/soc/arm/nordic_nrf/common/soc_secure.h
+++ b/soc/arm/nordic_nrf/common/soc_secure.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdint.h>
+#include <nrf.h>
+#include <hal/nrf_gpio.h>
+#include <hal/nrf_ficr.h>
+
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+#if NRF_GPIO_HAS_SEL
+void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu);
+#endif
+
+int soc_secure_mem_read(void *dst, void *src, size_t len);
+
+#if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
+static inline uint32_t soc_secure_read_xosc32mtrim(void)
+{
+	uint32_t xosc32mtrim;
+	int err;
+
+	err = soc_secure_mem_read(&xosc32mtrim,
+				  (void *)&NRF_FICR_S->XOSC32MTRIM,
+				  sizeof(xosc32mtrim));
+	__ASSERT(err == 0, "Secure read error (%d)", err);
+
+	return xosc32mtrim;
+}
+#endif /* defined(CONFIG_SOC_HFXO_CAP_INTERNAL) */
+
+static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
+{
+	int err;
+
+	err = soc_secure_mem_read(deviceid,
+				 (void *)&NRF_FICR_S->INFO.DEVICEID,
+				 2 * sizeof(uint32_t));
+	__ASSERT(err == 0, "Secure read error (%d)", err);
+}
+
+#else /* defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+
+static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
+{
+	(void)memcpy(dst, src, len);
+	return 0;
+}
+
+#if NRF_GPIO_HAS_SEL
+static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number,
+						  nrf_gpio_pin_sel_t mcu)
+{
+	nrf_gpio_pin_control_select(pin_number, mcu);
+}
+#endif /* NRF_GPIO_HAS_SEL */
+
+#if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
+static inline uint32_t soc_secure_read_xosc32mtrim(void)
+{
+	return NRF_FICR->XOSC32MTRIM;
+}
+#endif /* defined(CONFIG_SOC_HFXO_CAP_INTERNAL) */
+
+static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
+{
+	deviceid[0] = nrf_ficr_deviceid_get(NRF_FICR, 0);
+	deviceid[1] = nrf_ficr_deviceid_get(NRF_FICR, 1);
+}
+#endif /* defined CONFIG_TRUSTED_EXECUTION_NONSECURE */

--- a/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf51/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(soc.c)

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAA
@@ -1,0 +1,9 @@
+# Nordic Semiconductor nRF51822 MCU
+
+# Copyright (c) 2016 Linaro Limited
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC
+	default "nRF51822_QFAA"
+	depends on SOC_NRF51822_QFAA

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAB
@@ -1,0 +1,9 @@
+# Nordic Semiconductor nRF51822 MCU
+
+# Copyright (c) 2016 Linaro Limited
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC
+	default "nRF51822_QFAB"
+	depends on SOC_NRF51822_QFAB

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.nrf51822_QFAC
@@ -1,0 +1,9 @@
+# Nordic Semiconductor nRF51822 MCU
+
+# Copyright (c) 2016 Linaro Limited
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC
+	default "nRF51822_QFAC"
+	depends on SOC_NRF51822_QFAC

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.defconfig.series
@@ -1,0 +1,21 @@
+# Nordic Semiconductor nRF51 MCU line
+
+# Copyright (c) 2016 Linaro Limited
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF51X
+
+rsource "Kconfig.defconfig.nrf51*"
+
+config SOC_SERIES
+	default "nrf51"
+
+config NUM_IRQS
+	default 26
+
+# If the kernel has timer support, enable the timer
+config NRF_RTC_TIMER
+	default y if SYS_CLOCK_EXISTS
+
+endif # SOC_SERIES_NRF51X

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.series
@@ -1,0 +1,17 @@
+# Nordic Semiconductor nRF51 MCU line
+
+# Copyright (c) 2016 Linaro Limited
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NRF51X
+	bool "Nordic Semiconductor nRF51 series MCU"
+	select ARM
+	select CPU_CORTEX_M0
+	select SOC_FAMILY_NRF
+	imply XIP
+	select HAS_NRFX
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
+	select HAS_POWEROFF
+	help
+	  Enable support for NRF51 MCU series

--- a/soc/arm/nordic_nrf/nrf51/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf51/Kconfig.soc
@@ -1,0 +1,19 @@
+# Nordic Semiconductor nRF51 MCU line
+
+# Copyright (c) 2016 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+choice
+	prompt "nRF51x MCU Selection"
+	depends on SOC_SERIES_NRF51X
+
+config SOC_NRF51822_QFAA
+	bool "NRF51822_QFAA"
+
+config SOC_NRF51822_QFAB
+	bool "NRF51822_QFAB"
+
+config SOC_NRF51822_QFAC
+	bool "NRF51822_QFAC"
+
+endchoice

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ * Copyright (c) 2016 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for Nordic Semiconductor nRF51 family processor
+ *
+ * This module provides routines to initialize and support board-level hardware
+ * for the Nordic Semiconductor nRF51 family processor.
+ */
+
+#include <zephyr/kernel.h>
+#include <hal/nrf_power.h>
+#include <soc/nrfx_coredep.h>
+#include <zephyr/logging/log.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
+#define DELAY_CALL_OVERHEAD_US 2
+
+void arch_busy_wait(uint32_t time_us)
+{
+	if (time_us <= DELAY_CALL_OVERHEAD_US) {
+		return;
+	}
+
+	time_us -= DELAY_CALL_OVERHEAD_US;
+	nrfx_coredep_delay_us(time_us);
+}

--- a/soc/arm/nordic_nrf/nrf51/soc.h
+++ b/soc/arm/nordic_nrf/nrf51/soc.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file SoC configuration macros for the Nordic nRF51 family processors.
+ */
+
+#ifndef _NORDICSEMI_NRF51_SOC_H_
+#define _NORDICSEMI_NRF51_SOC_H_
+
+#include <soc_nrf_common.h>
+
+#define NRF51_POWER_RAMON_ADDRESS              0x40000524
+#define NRF51_POWER_RAMONB_ADDRESS             0x40000554
+#define NRF51_POWER_RAMONx_RAMxON_ONMODE_Msk   0x3
+
+#define FLASH_PAGE_ERASE_MAX_TIME_US 22300UL
+#define FLASH_PAGE_MAX_CNT 256UL
+
+#endif /* _NORDICSEMI_NRF51_SOC_H_ */

--- a/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(soc.c)
+
+if(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58 AND CONFIG_SPI_NRFX_SPIM)
+  message(WARNING "Both SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58 and an NRF SPIM driver are enabled, therefore PAN 58 will apply if RXD.MAXCNT == 1 and TXD.MAXCNT <= 1")
+endif()
+
+if(CONFIG_SOC_NRF52832)
+  if(NOT CONFIG_NRF52_ANOMALY_109_WORKAROUND)
+    if (CONFIG_NRFX_SPIS OR CONFIG_NRFX_SPIM OR CONFIG_NRFX_TWIM OR CONFIG_NRFX_PWM)
+      message(WARNING "NRF52_ANOMALY_109_WORKAROUND disabled with SPIS, SPIM, TWIM or PWM enabled. This will occasionally cause the first byte transmitted to be incorrect")
+    endif()
+  endif()
+endif()

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52805_CAAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52805_CAAA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF52805 MCU
+
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52805_CAAA
+
+config SOC
+	default "nRF52805_CAAA"
+
+config NUM_IRQS
+	default 26
+
+endif # SOC_NRF52805_CAAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52810_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52810_QFAA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF52810 MCU
+
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52810_QFAA
+
+config SOC
+	default "nRF52810_QFAA"
+
+config NUM_IRQS
+	default 30
+
+endif # SOC_NRF52810_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52811_QFAA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF52811 MCU
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52811_QFAA
+
+config SOC
+	default "nRF52811_QFAA"
+
+config NUM_IRQS
+	default 30
+
+endif # SOC_NRF52811_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52820_QDAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52820_QDAA
@@ -1,0 +1,16 @@
+# Nordic Semiconductor nRF52820 MCU
+
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52820_QDAA
+
+config SOC
+	string
+	default "nRF52820_QDAA"
+
+config NUM_IRQS
+	int
+	default 40
+
+endif # SOC_NRF52820_QDAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_CIAA
@@ -1,0 +1,18 @@
+# Nordic Semiconductor nRF52832 MCU
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52832_CIAA
+
+config SOC
+	default "nRF52832_CIAA"
+
+config NUM_IRQS
+	default 39
+
+config NRF52_ANOMALY_132_WORKAROUND
+	bool
+	default y
+
+endif # SOC_NRF52832_CIAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAA
@@ -1,0 +1,18 @@
+# Nordic Semiconductor nRF52832 MCU
+
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52832_QFAA
+
+config SOC
+	default "nRF52832_QFAA"
+
+config NUM_IRQS
+	default 39
+
+config NRF52_ANOMALY_132_WORKAROUND
+	bool
+	default y
+
+endif # SOC_NRF52832_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52832_QFAB
@@ -1,0 +1,18 @@
+# Nordic Semiconductor nRF52832 MCU
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52832_QFAB
+
+config SOC
+	default "nRF52832_QFAB"
+
+config NUM_IRQS
+	default 39
+
+config NRF52_ANOMALY_132_WORKAROUND
+	bool
+	default y
+
+endif # SOC_NRF52832_QFAB

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52833_QDAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52833_QDAA
@@ -1,0 +1,16 @@
+# Nordic Semiconductor nRF52833 MCU
+
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52833_QDAA
+
+config SOC
+	string
+	default "nRF52833_QDAA"
+
+config NUM_IRQS
+	int
+	default 48
+
+endif # SOC_NRF52833_QDAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52833_QIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52833_QIAA
@@ -1,0 +1,16 @@
+# Nordic Semiconductor nRF52833 MCU
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52833_QIAA
+
+config SOC
+	string
+	default "nRF52833_QIAA"
+
+config NUM_IRQS
+	int
+	default 48
+
+endif # SOC_NRF52833_QIAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QFAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QFAA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF52840 MCU
+
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52840_QFAA
+
+config SOC
+	default "nRF52840_QFAA"
+
+config NUM_IRQS
+	default 48
+
+endif # SOC_NRF52840_QFAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.nrf52840_QIAA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF52840 MCU
+
+# Copyright (c) 2016 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF52840_QIAA
+
+config SOC
+	default "nRF52840_QIAA"
+
+config NUM_IRQS
+	default 48
+
+endif # SOC_NRF52840_QIAA

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.defconfig.series
@@ -1,0 +1,17 @@
+# Nordic Semiconductor nRF52 MCU line
+
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF52X
+
+rsource "Kconfig.defconfig.nrf52*"
+
+config SOC_SERIES
+	default "nrf52"
+
+# If the kernel has timer support, enable the timer
+config NRF_RTC_TIMER
+	default y if SYS_CLOCK_EXISTS
+
+endif # SOC_SERIES_NRF52X

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.series
@@ -1,0 +1,20 @@
+# Nordic Semiconductor nRF52 MCU line
+
+# Copyright (c) 2016-2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NRF52X
+	bool "Nordic Semiconductor nRF52 series MCU"
+	select ARM
+	select SOC_COMPATIBLE_NRF52X
+	select CPU_CORTEX_M4
+	select CPU_HAS_ARM_MPU
+	select SOC_FAMILY_NRF
+	imply XIP
+	select HAS_NRFX
+	select HAS_NORDIC_DRIVERS
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
+	select HAS_SWO
+	select HAS_POWEROFF
+	help
+	  Enable support for NRF52 MCU series

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -1,0 +1,158 @@
+# Nordic Semiconductor nRF52 MCU line
+
+# Copyright (c) 2016-2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF52X
+
+config SOC_NRF52805
+	bool
+
+config SOC_NRF52810
+	bool
+
+config SOC_NRF52811
+	bool
+
+config SOC_NRF52820
+	bool
+
+config SOC_NRF52832
+	bool
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+
+config SOC_NRF52833
+	bool
+	select SOC_COMPATIBLE_NRF52833
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+
+config SOC_NRF52840
+	bool
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+
+choice
+	prompt "nRF52x MCU Selection"
+
+config SOC_NRF52805_CAAA
+	bool "NRF52805_CAAA"
+	select SOC_NRF52805
+
+config SOC_NRF52810_QFAA
+	bool "NRF52810_QFAA"
+	select SOC_NRF52810
+
+config SOC_NRF52811_QFAA
+	bool "NRF52811_QFAA"
+	select SOC_NRF52811
+
+config SOC_NRF52820_QDAA
+	bool "NRF52820_QDAA"
+	select SOC_NRF52820
+
+config SOC_NRF52832_CIAA
+	bool "NRF52832_CIAA"
+	select SOC_NRF52832
+
+config SOC_NRF52832_QFAA
+	bool "NRF52832_QFAA"
+	select SOC_NRF52832
+
+config SOC_NRF52832_QFAB
+	bool "NRF52832_QFAB"
+	select SOC_NRF52832
+
+config SOC_NRF52833_QDAA
+	bool "NRF52833_QDAA"
+	select SOC_NRF52833
+
+config SOC_NRF52833_QIAA
+	bool "NRF52833_QIAA"
+	select SOC_NRF52833
+
+config SOC_NRF52840_QFAA
+	bool "NRF52840_QFAA"
+	select SOC_NRF52840
+
+config SOC_NRF52840_QIAA
+	bool "NRF52840_QIAA"
+	select SOC_NRF52840
+
+endchoice
+
+config SOC_DCDC_NRF52X
+	bool
+	help
+	  Enable nRF52 series System on Chip DC/DC converter.
+
+config SOC_DCDC_NRF52X_HV
+	bool
+	depends on SOC_NRF52840_QIAA
+	help
+	  Enable nRF52 series System on Chip High Voltage DC/DC converter.
+
+config GPIO_AS_PINRESET
+	bool "[DEPRECATED] GPIO as pin reset (reset button)"
+	select DEPRECATED
+	help
+	  This option is deprecated, use devicetree instead. Example
+	  configuration:
+
+	  &uicr {
+	      gpio-as-nreset;
+	  };
+
+config NRF_ENABLE_ICACHE
+	bool "The instruction cache (I-Cache)"
+	depends on SOC_NRF52832 || SOC_NRF52833 || SOC_NRF52840
+	default y
+
+config NRF52_ANOMALY_132_DELAY_US
+	int "Anomaly 132 workaround delay (microseconds)"
+	default 330
+	range 0 330
+	depends on NRF52_ANOMALY_132_WORKAROUND
+	help
+	  Due to Anomaly 132 LF RC source may not start if restarted in certain
+	  window after stopping (230 us to 330 us). Software reset also stops the
+	  clock so if clock is initiated in certain window, the clock may also fail
+	  to start at reboot. A delay is added before starting LF clock to ensure
+	  that anomaly conditions are not met. Delay should be long enough to ensure
+	  that clock is started later than 330 us after reset. If crystal oscillator
+	  (XO) is used then low frequency clock initially starts with RC and then
+	  seamlessly switches to XO which has much longer startup time thus,
+	  depending on application, workaround may also need to be applied.
+	  Additional drivers initialization increases initialization time and delay
+	  may be shortened. Workaround is disabled by setting delay to 0.
+
+config NRF52_ANOMALY_198_WORKAROUND
+	bool "Anomaly 198 workaround"
+	default y
+	depends on SOC_NRF52840
+	depends on NRFX_SPIM3
+	help
+	  This anomaly applies to IC revisions "Engineering B" up to "3", the most
+	  recent one.
+
+config NRF52_ANOMALY_109_WORKAROUND
+	bool "Anomaly 109 workaround"
+	default y
+	depends on SOC_NRF52832
+	depends on NRFX_SPIS || NRFX_SPIM || NRFX_TWIM || NRFX_PWM
+	help
+	  Due to Anomaly 109 the first byte sent out by these peripherals is
+	  sometimes wrong. This occurs when the system enters IDLE and stops the
+	  64MHz clock at the same time as the peripheral that is using DMA is started.
+	  This anomaly applies to IC revisions up to "3", the most recent one.
+
+config NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE
+	int "Anomaly 109 workaround EGU instance"
+	depends on NRF52_ANOMALY_109_WORKAROUND
+	range 0 5
+	default 5
+	help
+	  EGU instance used by the nRF52 Anomaly 109 workaround for PWM.
+
+endif # SOC_SERIES_NRF52X

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for Nordic Semiconductor nRF52 family processor
+ *
+ * This module provides routines to initialize and support board-level hardware
+ * for the Nordic Semiconductor nRF52 family processor.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <hal/nrf_power.h>
+#include <soc/nrfx_coredep.h>
+#include <zephyr/logging/log.h>
+
+#include <cmsis_core.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
+static int nordicsemi_nrf52_init(void)
+{
+#ifdef CONFIG_NRF_ENABLE_ICACHE
+	/* Enable the instruction cache */
+	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
+#endif
+
+#if defined(CONFIG_SOC_DCDC_NRF52X)
+	nrf_power_dcdcen_set(NRF_POWER, true);
+#endif
+#if NRF_POWER_HAS_DCDCEN_VDDH && defined(CONFIG_SOC_DCDC_NRF52X_HV)
+	nrf_power_dcdcen_vddh_set(NRF_POWER, true);
+#endif
+
+	return 0;
+}
+
+void arch_busy_wait(uint32_t time_us)
+{
+	nrfx_coredep_delay_us(time_us);
+}
+
+SYS_INIT(nordicsemi_nrf52_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf52/soc.h
+++ b/soc/arm/nordic_nrf/nrf52/soc.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file SoC configuration macros for the Nordic Semiconductor nRF52 family processors.
+ */
+
+#ifndef _NORDICSEMI_NRF52_SOC_H_
+#define _NORDICSEMI_NRF52_SOC_H_
+
+#include <soc_nrf_common.h>
+
+#define FLASH_PAGE_ERASE_MAX_TIME_US	89700UL
+#define FLASH_PAGE_MAX_CNT		256UL
+
+#endif /* _NORDICSEMI_NRF52_SOC_H_ */

--- a/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf53/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(soc.c)
+
+zephyr_library_sources_ifdef(CONFIG_NRF53_SYNC_RTC sync_rtc.c)
+
+if (CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED AND
+    NOT CONFIG_SYS_CLOCK_EXISTS)
+  message(WARNING "
+    Your application may be affected by the anomaly 160 that concerns the
+    nRF5340 SoC. The related workaround cannot be applied, because your
+    application has the system clock disabled (CONFIG_SYS_CLOCK_EXISTS=n).
+    Consider enabling the system clock to apply the workaround.
+    " "
+    At your own risk, you can suppress this warning by setting
+    CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED=n.")
+endif()

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUAPP_QKAA
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUAPP_QKAA
@@ -1,0 +1,28 @@
+# Nordic Semiconductor nRF5340 Application MCU
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF5340_CPUAPP_QKAA
+
+config SOC
+	default "nRF5340_CPUAPP_QKAA"
+
+config NUM_IRQS
+	default 69
+
+config IEEE802154_NRF5
+	default IEEE802154
+
+config HEAP_MEM_POOL_ADD_SIZE_SOC
+	def_int 4096
+	depends on NRF_802154_SER_HOST
+
+if IPC_SERVICE_BACKEND_RPMSG
+
+config IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET
+	default y
+
+endif # IPC_SERVICE_BACKEND_RPMSG
+
+endif # SOC_NRF5340_CPUAPP_QKAA

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUNET_QKAA
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.nrf5340_CPUNET_QKAA
@@ -1,0 +1,25 @@
+# Nordic Semiconductor nRF5340 Network MCU
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF5340_CPUNET_QKAA
+
+config SOC
+	default "nRF5340_CPUNET_QKAA"
+
+config NUM_IRQS
+	default 30
+
+config IEEE802154_NRF5
+	default y
+	depends on IEEE802154
+
+config HEAP_MEM_POOL_ADD_SIZE_SOC
+	def_int 4096
+	depends on NRF_802154_SER_RADIO
+
+config LOG_DOMAIN_NAME
+	default "net"
+
+endif # SOC_NRF5340_CPUNET_QKAA

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.defconfig.series
@@ -1,0 +1,17 @@
+# Nordic Semiconductor nRF53 MCU line
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF53X
+
+rsource "Kconfig.defconfig.nrf53*"
+
+config SOC_SERIES
+	default "nrf53"
+
+# If the kernel has timer support, enable the timer
+config NRF_RTC_TIMER
+	default y if SYS_CLOCK_EXISTS
+
+endif # SOC_SERIES_NRF53X

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.series
@@ -1,0 +1,20 @@
+# Nordic Semiconductor nRF53 MCU line
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NRF53X
+	bool "Nordic Semiconductor nRF53 series MCU"
+	select ARM
+	select SOC_COMPATIBLE_NRF53X
+	select CPU_CORTEX_M33
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_ARM_MPU
+	select SOC_FAMILY_NRF
+	imply XIP
+	select HAS_NRFX
+	select HAS_NORDIC_DRIVERS
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
+	select HAS_SWO
+	help
+	 Enable support for NRF53 MCU series

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -1,0 +1,225 @@
+# Nordic Semiconductor nRF53 MCU line
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF53X
+config SOC_NRF5340_CPUAPP
+	bool
+	select CPU_HAS_NRF_IDAU
+	select CPU_HAS_FPU
+	select ARMV8_M_DSP
+	select HAS_POWEROFF
+	select SOC_COMPATIBLE_NRF5340_CPUAPP
+	imply SOC_NRF53_RTC_PRETICK
+	imply SOC_NRF53_ANOMALY_168_WORKAROUND
+
+config SOC_NRF5340_CPUNET
+	bool
+	select SOC_COMPATIBLE_NRF5340_CPUNET
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
+	imply SOC_NRF53_RTC_PRETICK if !WDT_NRFX
+	imply SOC_NRF53_ANOMALY_168_WORKAROUND
+
+choice
+	prompt "nRF53x MCU Selection"
+
+config SOC_NRF5340_CPUAPP_QKAA
+	bool "NRF5340_CPUAPP_QKAA"
+	select SOC_NRF5340_CPUAPP
+
+config SOC_NRF5340_CPUNET_QKAA
+	bool "NRF5340_CPUNET_QKAA"
+	select SOC_NRF5340_CPUNET
+
+endchoice
+
+config SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
+	bool "Workaround for nRF5340 anomaly 160"
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND
+	help
+	  Indicates that the workaround for the anomaly 160 that affects
+	  the nRF5340 SoC should be applied.
+	  This option is enabled by default for the Application MCU when
+	  DC/DC mode is enabled for the VREGMAIN or VREGRADIO regulator
+	  and always for the Network MCU.
+	  If this option is enabled, but the workaround cannot be applied,
+	  because the system clock is disabled, a related cmake warning is
+	  issued.
+
+config SOC_NRF53_ANOMALY_160_WORKAROUND
+	bool
+	depends on SYS_CLOCK_EXISTS
+	select ARM_ON_ENTER_CPU_IDLE_HOOK
+
+config SOC_NRF53_RTC_PRETICK
+	bool "Pre-tick workaround for nRF5340 anomaly 165"
+	depends on (SYS_CLOCK_EXISTS && SOC_NRF5340_CPUNET) || SOC_NRF5340_CPUAPP
+	select NRFX_DPPI
+	select ARM_ON_ENTER_CPU_IDLE_HOOK if SOC_NRF5340_CPUNET
+	select ARM_ON_ENTER_CPU_IDLE_PREPARE_HOOK if SOC_NRF5340_CPUNET
+	help
+	  Indicates that the pre-tick workaround for the anomaly 165 that affects
+	  the nRF5340 SoC should be applied. The workaround applies to wake ups caused
+	  by EVENTS_COMPARE and EVENTS_OVRFLW on RTC0 and RTC1 for which interrupts are
+	  enabled through INTENSET register. The case when these events are generated
+	  by EVTEN but without interrupts enabled through INTENSET is not handled.
+	  The EVENTS_TICK event is not handled.
+
+if SOC_NRF53_RTC_PRETICK
+
+config SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET
+	int "IPC 0 channel for RTC pretick"
+	range 0 15
+	default 10
+
+config SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET
+	int "IPC 1 channel for RTC pretick"
+	range 0 15
+	default 11
+
+endif
+
+config SOC_NRF53_ANOMALY_168_WORKAROUND
+	bool "Workaround for nRF5340 anomaly 168"
+	select ARM_ON_EXIT_CPU_IDLE
+	help
+	  Indicates that the workaround for the anomaly 168 that affects
+	  the nRF5340 SoC should be applied.
+	  The workaround involves execution of 8 NOP instructions when the CPU
+	  exist its idle state (when the WFI/WFE instruction returns) and it is
+	  enabled by default for both the application and network core.
+
+config SOC_NRF53_ANOMALY_168_WORKAROUND_FOR_EXECUTION_FROM_RAM
+	bool "Extend the workaround to execution at 128 MHz from RAM"
+	depends on SOC_NRF53_ANOMALY_168_WORKAROUND && SOC_NRF5340_CPUAPP
+	help
+	  Indicates that the anomaly 168 workaround is to be extended to cover
+	  also a specific case when the WFI/WFE instruction is executed at 128
+	  MHz from RAM. Then, 26 instead of 8 NOP instructions needs to be
+	  executed after WFI/WFE. This extension is not enabled by default.
+
+if SOC_NRF5340_CPUAPP
+
+config SOC_DCDC_NRF53X_APP
+	bool
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
+	help
+	  Enable nRF53 series System on Chip Application MCU DC/DC converter.
+
+config SOC_DCDC_NRF53X_NET
+	bool
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND_NEEDED
+	help
+	  Enable nRF53 series System on Chip Network MCU DC/DC converter.
+
+config SOC_DCDC_NRF53X_HV
+	bool
+	help
+	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
+
+config NRF_SPU_FLASH_REGION_SIZE
+	hex
+	default 0x4000
+	help
+	  FLASH region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_SIZE
+	hex
+	default 0x2000
+	help
+	  RAM region size for the NRF_SPU peripheral
+
+config SOC_NRF_GPIO_FORWARDER_FOR_NRF5340
+	bool
+	depends on NRF_SOC_SECURE_SUPPORTED
+	help
+	  hidden option for including the nRF GPIO pin forwarding
+
+if !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
+
+config SOC_ENABLE_LFXO
+	bool "LFXO"
+	default y
+	help
+	  Enable the low-frequency oscillator (LFXO) functionality on XL1 and
+	  XL2 pins.
+	  This option must be enabled if either application or network core is
+	  to use the LFXO. Otherwise, XL1 and XL2 pins will behave as regular
+	  GPIOs.
+
+choice SOC_LFXO_LOAD_CAPACITANCE
+	prompt "LFXO load capacitance"
+	depends on SOC_ENABLE_LFXO
+	default SOC_LFXO_CAP_INT_7PF
+
+config SOC_LFXO_CAP_EXTERNAL
+	bool "Use external load capacitors"
+
+config SOC_LFXO_CAP_INT_6PF
+	bool "6 pF internal load capacitance"
+
+config SOC_LFXO_CAP_INT_7PF
+	bool "7 pF internal load capacitance"
+
+config SOC_LFXO_CAP_INT_9PF
+	bool "9 pF internal load capacitance"
+
+endchoice
+
+choice SOC_HFXO_LOAD_CAPACITANCE
+	prompt "HFXO load capacitance"
+	default SOC_HFXO_CAP_DEFAULT
+
+config SOC_HFXO_CAP_DEFAULT
+	bool "SoC default"
+	help
+	  When this option is used, the SoC initialization routine does not
+	  touch the XOSC32MCAPS register value, so the default setting for
+	  the SoC is in effect. Please note that this may not necessarily be
+	  the reset value (0) for the register, as the register can be set
+	  during the device trimming in the SystemInit() function.
+
+config SOC_HFXO_CAP_EXTERNAL
+	bool "Use external load capacitors"
+
+config SOC_HFXO_CAP_INTERNAL
+	bool "Use internal load capacitors"
+	depends on NRF_SOC_SECURE_SUPPORTED
+
+endchoice
+
+config SOC_HFXO_CAP_INT_VALUE_X2
+	int "Doubled value of HFXO internal load capacitors (in pF)"
+	depends on SOC_HFXO_CAP_INTERNAL
+	range 14 40
+	help
+	  Internal capacitors ranging from 7.0 pF to 20.0 pF in 0.5 pF steps
+	  can be enabled on pins XC1 and XC2. This option specifies doubled
+	  capacitance value for the two capacitors. Set it to 14 to get 7.0 pF
+	  for each capacitor, 15 to get 7.5 pF, and so on.
+
+endif # !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
+
+endif # SOC_NRF5340_CPUAPP
+
+
+config NRF_ENABLE_CACHE
+	bool "Cache"
+	depends on (SOC_NRF5340_CPUAPP && (!TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM)) \
+			|| SOC_NRF5340_CPUNET
+	default y
+	help
+	  Instruction and Data cache is available on nRF5340 CPUAPP
+	  (Application MCU). It may only be accessed by Secure code.
+
+	  Instruction cache only (I-Cache) is available in nRF5340
+	  CPUNET (Network MCU).
+
+config BUILD_WITH_TFM
+	# TF-M nRF53 platform enables the cache unconditionally.
+	select NRF_ENABLE_CACHE if SOC_NRF5340_CPUAPP
+
+rsource "Kconfig.sync_rtc"
+
+endif # SOC_SERIES_NRF53X

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.sync_rtc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.sync_rtc
@@ -1,0 +1,77 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config NRF53_SYNC_RTC
+	bool "RTC clock synchronization"
+	default y if LOG && !LOG_MODE_MINIMAL
+	depends on NRF_RTC_TIMER
+	select NRFX_DPPI
+	select MBOX if !IPM
+
+if NRF53_SYNC_RTC
+
+module = SYNC_RTC
+module-str = Synchronized RTC
+source "subsys/logging/Kconfig.template.log_config"
+
+config NRF53_SYNC_RTC_INIT_PRIORITY
+	int "nRF53 Synchronized RTC init priority"
+	default APPLICATION_INIT_PRIORITY
+	help
+	  nRF53 Synchronized RTC initialization priority.
+
+config NRF_RTC_TIMER_USER_CHAN_COUNT
+	default 2 if NRF_802154_RADIO_DRIVER && SOC_COMPATIBLE_NRF5340_CPUNET
+	default 3 if NRF_802154_RADIO_DRIVER
+	default 1
+
+config NRF53_SYNC_RTC_LOG_TIMESTAMP
+	bool "Use Synchronized RTC for logging timestamp"
+	default y
+
+config NRF53_SYNC_RTC_IPM_OUT
+	int "IPM channel from APP to NET"
+	range 0 15
+	default 7 if SOC_COMPATIBLE_NRF5340_CPUAPP
+	default 8
+
+config NRF53_SYNC_RTC_IPM_IN
+	int "IPM channel from APP to NET"
+	range 0 15
+	default 8 if SOC_COMPATIBLE_NRF5340_CPUAPP
+	default 7
+
+ipm_num = 0
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 1
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 2
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 3
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 4
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 5
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 6
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 7
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 8
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 9
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 10
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 11
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 12
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 13
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 14
+rsource "Kconfig.sync_rtc_ipm"
+ipm_num = 15
+rsource "Kconfig.sync_rtc_ipm"
+
+endif # NRF53_SYNC_RTC

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.sync_rtc_ipm
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.sync_rtc_ipm
@@ -1,0 +1,12 @@
+# nRF IPM driver configuration
+
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config IPM_MSG_CH_$(ipm_num)_ENABLE
+	default y
+	depends on NRF53_SYNC_RTC_IPM_IN = $(ipm_num)
+
+config IPM_MSG_CH_$(ipm_num)_RX
+	default y
+	depends on NRF53_SYNC_RTC_IPM_IN = $(ipm_num)

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for Nordic Semiconductor nRF53 family processor
+ *
+ * This module provides routines to initialize and support board-level hardware
+ * for the Nordic Semiconductor nRF53 family processor.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/barrier.h>
+#include <soc/nrfx_coredep.h>
+#include <zephyr/logging/log.h>
+#include <nrf_erratas.h>
+#include <hal/nrf_power.h>
+#include <hal/nrf_ipc.h>
+#include <helpers/nrfx_gppi.h>
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/devicetree.h>
+#include <hal/nrf_cache.h>
+#include <hal/nrf_gpio.h>
+#include <hal/nrf_oscillators.h>
+#include <hal/nrf_regulators.h>
+#elif defined(CONFIG_SOC_NRF5340_CPUNET)
+#include <hal/nrf_nvmc.h>
+#endif
+#if defined(CONFIG_PM_S2RAM)
+#include <hal/nrf_vmc.h>
+#endif
+#include <hal/nrf_wdt.h>
+#include <hal/nrf_rtc.h>
+#include <soc_secure.h>
+
+#include <cmsis_core.h>
+
+#define PIN_XL1 0
+#define PIN_XL2 1
+
+#define RTC1_PRETICK_CC_CHAN (RTC1_CC_NUM - 1)
+
+/* Mask of CC channels capable of generating interrupts, see nrf_rtc_timer.c */
+#define RTC1_PRETICK_SELECTED_CC_MASK   BIT_MASK(CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT + 1U)
+#define RTC0_PRETICK_SELECTED_CC_MASK	BIT_MASK(NRF_RTC_CC_COUNT_MAX)
+
+#if defined(CONFIG_SOC_NRF_GPIO_FORWARDER_FOR_NRF5340)
+#define GPIOS_PSEL_BY_IDX(node_id, prop, idx) \
+	NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, idx),
+#define ALL_GPIOS_IN_NODE(node_id) \
+	DT_FOREACH_PROP_ELEM(node_id, gpios, GPIOS_PSEL_BY_IDX)
+#define ALL_GPIOS_IN_FORWARDER(node_id) \
+	DT_FOREACH_CHILD(node_id, ALL_GPIOS_IN_NODE)
+#endif
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
+#if defined(CONFIG_PM_S2RAM)
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define RAM_N_BLOCK	(8)
+#elif defined(CONFIG_SOC_NRF5340_CPUNET)
+#define RAM_N_BLOCK	(4)
+#endif /* CONFIG_SOC_NRF5340_CPUAPP || CONFIG_SOC_NRF5340_CPUNET */
+
+#define MASK_ALL_SECT	(VMC_RAM_POWER_S0RETENTION_Msk  | VMC_RAM_POWER_S1RETENTION_Msk  | \
+			 VMC_RAM_POWER_S2RETENTION_Msk  | VMC_RAM_POWER_S3RETENTION_Msk  | \
+			 VMC_RAM_POWER_S4RETENTION_Msk  | VMC_RAM_POWER_S5RETENTION_Msk  | \
+			 VMC_RAM_POWER_S6RETENTION_Msk  | VMC_RAM_POWER_S7RETENTION_Msk  | \
+			 VMC_RAM_POWER_S8RETENTION_Msk  | VMC_RAM_POWER_S9RETENTION_Msk  | \
+			 VMC_RAM_POWER_S10RETENTION_Msk | VMC_RAM_POWER_S11RETENTION_Msk | \
+			 VMC_RAM_POWER_S12RETENTION_Msk | VMC_RAM_POWER_S13RETENTION_Msk | \
+			 VMC_RAM_POWER_S14RETENTION_Msk | VMC_RAM_POWER_S15RETENTION_Msk)
+
+static void enable_ram_retention(void)
+{
+	/*
+	 * Enable RAM retention for *ALL* the SRAM
+	 */
+	for (size_t n = 0; n < RAM_N_BLOCK; n++) {
+		nrf_vmc_ram_block_retention_set(NRF_VMC, n, MASK_ALL_SECT);
+	}
+
+}
+#endif /* CONFIG_PM_S2RAM */
+
+#if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND)
+/* This code prevents the CPU from entering sleep again if it already
+ * entered sleep 5 times within last 200 us.
+ */
+static bool nrf53_anomaly_160_check(void)
+{
+	/* System clock cycles needed to cover 200 us window. */
+	const uint32_t window_cycles =
+		DIV_ROUND_UP(200 * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+				 1000000);
+	static uint32_t timestamps[5];
+	static bool timestamps_filled;
+	static uint8_t current;
+	uint8_t oldest = (current + 1) % ARRAY_SIZE(timestamps);
+	uint32_t now = k_cycle_get_32();
+
+	if (timestamps_filled &&
+	    /* + 1 because only fully elapsed cycles need to be counted. */
+	    (now - timestamps[oldest]) < (window_cycles + 1)) {
+		return false;
+	}
+
+	/* Check if the CPU actually entered sleep since the last visit here
+	 * (WFE/WFI could return immediately if the wake-up event was already
+	 * registered).
+	 */
+	if (nrf_power_event_check(NRF_POWER, NRF_POWER_EVENT_SLEEPENTER)) {
+		nrf_power_event_clear(NRF_POWER, NRF_POWER_EVENT_SLEEPENTER);
+		/* If so, update the index at which the current timestamp is
+		 * to be stored so that it replaces the oldest one, otherwise
+		 * (when the CPU did not sleep), the recently stored timestamp
+		 * is updated.
+		 */
+		current = oldest;
+		if (current == 0) {
+			timestamps_filled = true;
+		}
+	}
+
+	timestamps[current] = k_cycle_get_32();
+
+	return true;
+}
+#endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND */
+
+#if defined(CONFIG_SOC_NRF53_RTC_PRETICK) && defined(CONFIG_SOC_NRF5340_CPUNET)
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_WDT_NRFX),
+	     "For CONFIG_SOC_NRF53_RTC_PRETICK watchdog is used internally for the pre-tick workaround on nRF5340 cpunet. Application cannot use the watchdog.");
+
+static inline uint32_t rtc_counter_sub(uint32_t a, uint32_t b)
+{
+	return (a - b) & NRF_RTC_COUNTER_MAX;
+}
+
+static bool rtc_ticks_to_next_event_get(NRF_RTC_Type *rtc, uint32_t selected_cc_mask, uint32_t cntr,
+					uint32_t *ticks_to_next_event)
+{
+	bool result = false;
+
+	/* Let's preload register to speed-up. */
+	uint32_t reg_intenset = rtc->INTENSET;
+
+	/* Note: TICK event not handled. */
+
+	if (reg_intenset & NRF_RTC_INT_OVERFLOW_MASK) {
+		/* Overflow can generate an interrupt. */
+		*ticks_to_next_event = NRF_RTC_COUNTER_MAX + 1U - cntr;
+		result = true;
+	}
+
+	for (uint32_t chan = 0; chan < NRF_RTC_CC_COUNT_MAX; chan++) {
+		if ((selected_cc_mask & (1U << chan)) &&
+		    (reg_intenset & NRF_RTC_CHANNEL_INT_MASK(chan))) {
+			/* The CC is in selected mask and is can generate an interrupt. */
+			uint32_t cc = nrf_rtc_cc_get(rtc, chan);
+			uint32_t ticks_to_fire = rtc_counter_sub(cc, cntr);
+
+			if (ticks_to_fire == 0U) {
+				/* When ticks_to_fire == 0, the event should have been just
+				 * generated the interrupt can be already handled or be pending.
+				 * However the next event is expected to be after counter wraps.
+				 */
+				ticks_to_fire = NRF_RTC_COUNTER_MAX + 1U;
+			}
+
+			if (!result) {
+				*ticks_to_next_event = ticks_to_fire;
+				result = true;
+			} else if (ticks_to_fire < *ticks_to_next_event) {
+				*ticks_to_next_event = ticks_to_fire;
+				result = true;
+			} else {
+				/* CC that fires no earlier than already found. */
+			}
+		}
+	}
+
+	return result;
+}
+
+static void rtc_counter_synchronized_get(NRF_RTC_Type *rtc_a, NRF_RTC_Type *rtc_b,
+					 uint32_t *counter_a, uint32_t *counter_b)
+{
+	do {
+		*counter_a = nrf_rtc_counter_get(rtc_a);
+		barrier_dmem_fence_full();
+		*counter_b = nrf_rtc_counter_get(rtc_b);
+		barrier_dmem_fence_full();
+	} while (*counter_a != nrf_rtc_counter_get(rtc_a));
+}
+
+static uint8_t cpu_idle_prepare_monitor_dummy;
+static bool cpu_idle_prepare_allows_sleep;
+
+static void cpu_idle_prepare_monitor_begin(void)
+{
+	__LDREXB(&cpu_idle_prepare_monitor_dummy);
+}
+
+/* Returns 0 if no exception preempted since the last call to cpu_idle_prepare_monitor_begin. */
+static bool cpu_idle_prepare_monitor_end(void)
+{
+	/* The value stored is irrelevant. If any exception took place after
+	 * cpu_idle_prepare_monitor_begin, the the local monitor is cleared and
+	 * the store fails returning 1.
+	 * See Arm v8-M Architecture Reference Manual:
+	 *   Chapter B9.2 The local monitors
+	 *   Chapter B9.4 Exclusive access instructions and the monitors
+	 * See Arm Cortex-M33 Processor Technical Reference Manual
+	 *   Chapter 3.5 Exclusive monitor
+	 */
+	return __STREXB(0U, &cpu_idle_prepare_monitor_dummy);
+}
+
+static void rtc_pretick_finish_previous(void)
+{
+	NRF_IPC->PUBLISH_RECEIVE[CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET] &=
+			~IPC_PUBLISH_RECEIVE_EN_Msk;
+
+	nrf_rtc_event_clear(NRF_RTC1, NRF_RTC_CHANNEL_EVENT_ADDR(RTC1_PRETICK_CC_CHAN));
+}
+
+
+void z_arm_on_enter_cpu_idle_prepare(void)
+{
+	bool ok_to_sleep = true;
+
+	cpu_idle_prepare_monitor_begin();
+
+	uint32_t rtc_counter = 0U;
+	uint32_t rtc_ticks_to_next_event = 0U;
+	uint32_t rtc0_counter = 0U;
+	uint32_t rtc0_ticks_to_next_event = 0U;
+
+	rtc_counter_synchronized_get(NRF_RTC1, NRF_RTC0, &rtc_counter, &rtc0_counter);
+
+	bool rtc_scheduled = rtc_ticks_to_next_event_get(NRF_RTC1, RTC1_PRETICK_SELECTED_CC_MASK,
+							 rtc_counter, &rtc_ticks_to_next_event);
+
+	if (rtc_ticks_to_next_event_get(NRF_RTC0, RTC0_PRETICK_SELECTED_CC_MASK, rtc0_counter,
+					&rtc0_ticks_to_next_event)) {
+		/* An event is scheduled on RTC0. */
+		if (!rtc_scheduled) {
+			rtc_ticks_to_next_event = rtc0_ticks_to_next_event;
+			rtc_scheduled = true;
+		} else if (rtc0_ticks_to_next_event < rtc_ticks_to_next_event) {
+			rtc_ticks_to_next_event = rtc0_ticks_to_next_event;
+		} else {
+			/* Event on RTC0 will not happen earlier than already found. */
+		}
+	}
+
+	if (rtc_scheduled) {
+		static bool rtc_pretick_cc_set_on_time;
+		/* The pretick should happen 1 tick before the earliest scheduled event
+		 * that can trigger an interrupt.
+		 */
+		uint32_t rtc_pretick_cc_val = (rtc_counter + rtc_ticks_to_next_event - 1U)
+						& NRF_RTC_COUNTER_MAX;
+
+		if (rtc_pretick_cc_val != nrf_rtc_cc_get(NRF_RTC1, RTC1_PRETICK_CC_CHAN)) {
+			/* The CC for pretick needs to be updated. */
+			rtc_pretick_finish_previous();
+			nrf_rtc_cc_set(NRF_RTC1, RTC1_PRETICK_CC_CHAN, rtc_pretick_cc_val);
+
+			if (rtc_ticks_to_next_event >= NRF_RTC_COUNTER_MAX/2) {
+				/* Pretick is scheduled so far in the future, assumed on time. */
+				rtc_pretick_cc_set_on_time = true;
+			} else {
+				/* Let's check if we updated CC on time, so that the CC can
+				 * take effect.
+				 */
+				barrier_dmem_fence_full();
+				rtc_counter = nrf_rtc_counter_get(NRF_RTC1);
+				uint32_t pretick_cc_to_counter =
+						rtc_counter_sub(rtc_pretick_cc_val, rtc_counter);
+
+				if ((pretick_cc_to_counter < 3) ||
+				    (pretick_cc_to_counter >= NRF_RTC_COUNTER_MAX/2)) {
+					/* The COUNTER value is close enough to the expected
+					 * pretick CC or has just expired, so the pretick event
+					 * generation is not guaranteed.
+					 */
+					rtc_pretick_cc_set_on_time = false;
+				} else {
+					/* The written rtc_pretick_cc is guaranteed to to trigger
+					 * compare event.
+					 */
+					rtc_pretick_cc_set_on_time = true;
+				}
+			}
+		} else {
+			/* The CC for pretick doesn't need to be updated, however
+			 * rtc_pretick_cc_set_on_time still holds if we managed to set it on time.
+			 */
+		}
+
+		/* If the CC for pretick is set on time, so the pretick CC event can be reliably
+		 * generated then allow to sleep. Otherwise (the CC for pretick cannot be reliably
+		 * generated, because CC was set very short to it's fire time) sleep not at all.
+		 */
+		ok_to_sleep = rtc_pretick_cc_set_on_time;
+	} else {
+		/* No events on any RTC timers are scheduled. */
+	}
+
+	if (ok_to_sleep) {
+		NRF_IPC->PUBLISH_RECEIVE[CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET] |=
+			IPC_PUBLISH_RECEIVE_EN_Msk;
+		if (!nrf_rtc_event_check(NRF_RTC1,
+				NRF_RTC_CHANNEL_EVENT_ADDR(RTC1_PRETICK_CC_CHAN))) {
+			NRF_WDT->TASKS_STOP = 1;
+			/* Check if any event did not occur after we checked for
+			 * stopping condition. If yes, we might have stopped WDT
+			 * when it should be running. Restart it.
+			 */
+			if (nrf_rtc_event_check(NRF_RTC1,
+					NRF_RTC_CHANNEL_EVENT_ADDR(RTC1_PRETICK_CC_CHAN))) {
+				NRF_WDT->TASKS_START = 1;
+			}
+		}
+	}
+
+	cpu_idle_prepare_allows_sleep = ok_to_sleep;
+}
+#endif /* CONFIG_SOC_NRF53_RTC_PRETICK && CONFIG_SOC_NRF5340_CPUNET */
+
+#if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND) || \
+	(defined(CONFIG_SOC_NRF53_RTC_PRETICK) && defined(CONFIG_SOC_NRF5340_CPUNET))
+bool z_arm_on_enter_cpu_idle(void)
+{
+	bool ok_to_sleep = true;
+
+#if defined(CONFIG_SOC_NRF53_RTC_PRETICK) && defined(CONFIG_SOC_NRF5340_CPUNET)
+	if (cpu_idle_prepare_monitor_end() == 0) {
+		/* No exception happened since cpu_idle_prepare_monitor_begin.
+		 * We can trust the outcome of. z_arm_on_enter_cpu_idle_prepare
+		 */
+		ok_to_sleep = cpu_idle_prepare_allows_sleep;
+	} else {
+		/* Exception happened since cpu_idle_prepare_monitor_begin.
+		 * The values which z_arm_on_enter_cpu_idle_prepare could be changed
+		 * by the exception, so we can not trust to it's outcome.
+		 * Do not sleep at all, let's try in the next iteration of idle loop.
+		 */
+		ok_to_sleep = false;
+	}
+#endif
+
+#if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND)
+	if (ok_to_sleep) {
+		ok_to_sleep = nrf53_anomaly_160_check();
+
+#if (LOG_LEVEL >= LOG_LEVEL_DBG)
+		static bool suppress_message;
+
+		if (ok_to_sleep) {
+			suppress_message = false;
+		} else if (!suppress_message) {
+			LOG_DBG("Anomaly 160 trigger conditions detected.");
+			suppress_message = true;
+		}
+#endif
+	}
+#endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND */
+
+#if defined(CONFIG_SOC_NRF53_RTC_PRETICK) && defined(CONFIG_SOC_NRF5340_CPUNET)
+	if (!ok_to_sleep) {
+		NRF_IPC->PUBLISH_RECEIVE[CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET] &=
+			~IPC_PUBLISH_RECEIVE_EN_Msk;
+		NRF_WDT->TASKS_STOP = 1;
+	}
+#endif
+
+	return ok_to_sleep;
+}
+#endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND ||
+	* (CONFIG_SOC_NRF53_RTC_PRETICK && CONFIG_SOC_NRF5340_CPUNET)
+	*/
+
+#if CONFIG_SOC_NRF53_RTC_PRETICK
+#ifdef CONFIG_SOC_NRF5340_CPUAPP
+/* RTC pretick - application core part. */
+static int rtc_pretick_cpuapp_init(void)
+{
+	uint8_t ch;
+	nrfx_err_t err;
+	nrf_ipc_event_t ipc_event =
+		nrf_ipc_receive_event_get(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET);
+	nrf_ipc_task_t ipc_task =
+		nrf_ipc_send_task_get(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET);
+	uint32_t task_ipc = nrf_ipc_task_address_get(NRF_IPC, ipc_task);
+	uint32_t evt_ipc = nrf_ipc_event_address_get(NRF_IPC, ipc_event);
+
+	err = nrfx_gppi_channel_alloc(&ch);
+	if (err != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+
+	nrf_ipc_receive_config_set(NRF_IPC, CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET,
+				   BIT(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET));
+	nrf_ipc_send_config_set(NRF_IPC, CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET,
+				   BIT(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET));
+
+	nrfx_gppi_task_endpoint_setup(ch, task_ipc);
+	nrfx_gppi_event_endpoint_setup(ch, evt_ipc);
+	nrfx_gppi_channels_enable(BIT(ch));
+
+	return 0;
+}
+#else /* CONFIG_SOC_NRF5340_CPUNET */
+
+void rtc_pretick_rtc0_isr_hook(void)
+{
+	rtc_pretick_finish_previous();
+}
+
+void rtc_pretick_rtc1_isr_hook(void)
+{
+	rtc_pretick_finish_previous();
+}
+
+static int rtc_pretick_cpunet_init(void)
+{
+	uint8_t ppi_ch;
+	nrf_ipc_task_t ipc_task =
+		nrf_ipc_send_task_get(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET);
+	nrf_ipc_event_t ipc_event =
+		nrf_ipc_receive_event_get(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET);
+	uint32_t task_ipc = nrf_ipc_task_address_get(NRF_IPC, ipc_task);
+	uint32_t evt_ipc = nrf_ipc_event_address_get(NRF_IPC, ipc_event);
+	uint32_t task_wdt = nrf_wdt_task_address_get(NRF_WDT, NRF_WDT_TASK_START);
+	uint32_t evt_cc = nrf_rtc_event_address_get(NRF_RTC1,
+				NRF_RTC_CHANNEL_EVENT_ADDR(RTC1_PRETICK_CC_CHAN));
+
+	/* Configure Watchdog to allow stopping. */
+	nrf_wdt_behaviour_set(NRF_WDT, WDT_CONFIG_STOPEN_Msk | BIT(4));
+	*((volatile uint32_t *)0x41203120) = 0x14;
+
+	/* Configure IPC */
+	nrf_ipc_receive_config_set(NRF_IPC, CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET,
+				   BIT(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_TO_NET));
+	nrf_ipc_send_config_set(NRF_IPC, CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET,
+				   BIT(CONFIG_SOC_NRF53_RTC_PRETICK_IPC_CH_FROM_NET));
+
+	/* Allocate PPI channel for RTC Compare event publishers that starts WDT. */
+	nrfx_err_t err = nrfx_gppi_channel_alloc(&ppi_ch);
+
+	if (err != NRFX_SUCCESS) {
+		return -ENOMEM;
+	}
+
+	nrfx_gppi_event_endpoint_setup(ppi_ch, evt_cc);
+	nrfx_gppi_task_endpoint_setup(ppi_ch, task_ipc);
+	nrfx_gppi_event_endpoint_setup(ppi_ch, evt_ipc);
+	nrfx_gppi_task_endpoint_setup(ppi_ch, task_wdt);
+	nrfx_gppi_channels_enable(BIT(ppi_ch));
+
+	nrf_rtc_event_enable(NRF_RTC1, NRF_RTC_CHANNEL_INT_MASK(RTC1_PRETICK_CC_CHAN));
+	nrf_rtc_event_clear(NRF_RTC1, NRF_RTC_CHANNEL_EVENT_ADDR(RTC1_PRETICK_CC_CHAN));
+
+	return 0;
+}
+#endif /* CONFIG_SOC_NRF5340_CPUNET */
+
+static int rtc_pretick_init(void)
+{
+#ifdef CONFIG_SOC_NRF5340_CPUAPP
+	return rtc_pretick_cpuapp_init();
+#else
+	return rtc_pretick_cpunet_init();
+#endif
+}
+#endif /* CONFIG_SOC_NRF53_RTC_PRETICK */
+
+
+static int nordicsemi_nrf53_init(void)
+{
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF_ENABLE_CACHE)
+#if !defined(CONFIG_BUILD_WITH_TFM)
+	/* Enable the instruction & data cache.
+	 * This can only be done from secure code.
+	 * This is handled by the TF-M platform so we skip it when TF-M is
+	 * enabled.
+	 */
+	nrf_cache_enable(NRF_CACHE);
+#endif
+#elif defined(CONFIG_SOC_NRF5340_CPUNET) && defined(CONFIG_NRF_ENABLE_CACHE)
+	nrf_nvmc_icache_config_set(NRF_NVMC, NRF_NVMC_ICACHE_ENABLE);
+#endif
+
+#if defined(CONFIG_SOC_ENABLE_LFXO)
+	nrf_oscillators_lfxo_cap_set(NRF_OSCILLATORS,
+		IS_ENABLED(CONFIG_SOC_LFXO_CAP_INT_6PF) ?
+			NRF_OSCILLATORS_LFXO_CAP_6PF :
+		IS_ENABLED(CONFIG_SOC_LFXO_CAP_INT_7PF) ?
+			NRF_OSCILLATORS_LFXO_CAP_7PF :
+		IS_ENABLED(CONFIG_SOC_LFXO_CAP_INT_9PF) ?
+			NRF_OSCILLATORS_LFXO_CAP_9PF :
+			NRF_OSCILLATORS_LFXO_CAP_EXTERNAL);
+#if !defined(CONFIG_BUILD_WITH_TFM)
+	/* This can only be done from secure code.
+	 * This is handled by the TF-M platform so we skip it when TF-M is
+	 * enabled.
+	 */
+	nrf_gpio_pin_control_select(PIN_XL1, NRF_GPIO_PIN_SEL_PERIPHERAL);
+	nrf_gpio_pin_control_select(PIN_XL2, NRF_GPIO_PIN_SEL_PERIPHERAL);
+#endif /* !defined(CONFIG_BUILD_WITH_TFM) */
+#endif /* defined(CONFIG_SOC_ENABLE_LFXO) */
+#if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
+	/* This register is only accessible from secure code. */
+	uint32_t xosc32mtrim = soc_secure_read_xosc32mtrim();
+	/* The SLOPE field is in the two's complement form, hence this special
+	 * handling. Ideally, it would result in just one SBFX instruction for
+	 * extracting the slope value, at least gcc is capable of producing such
+	 * output, but since the compiler apparently tries first to optimize
+	 * additions and subtractions, it generates slightly less than optimal
+	 * code.
+	 */
+	uint32_t slope_field = (xosc32mtrim & FICR_XOSC32MTRIM_SLOPE_Msk)
+			       >> FICR_XOSC32MTRIM_SLOPE_Pos;
+	uint32_t slope_mask = FICR_XOSC32MTRIM_SLOPE_Msk
+			      >> FICR_XOSC32MTRIM_SLOPE_Pos;
+	uint32_t slope_sign = (slope_mask - (slope_mask >> 1));
+	int32_t slope = (int32_t)(slope_field ^ slope_sign) - (int32_t)slope_sign;
+	uint32_t offset = (xosc32mtrim & FICR_XOSC32MTRIM_OFFSET_Msk)
+			  >> FICR_XOSC32MTRIM_OFFSET_Pos;
+	/* As specified in the nRF5340 PS:
+	 * CAPVALUE = (((FICR->XOSC32MTRIM.SLOPE+56)*(CAPACITANCE*2-14))
+	 *            +((FICR->XOSC32MTRIM.OFFSET-8)<<4)+32)>>6;
+	 * where CAPACITANCE is the desired capacitor value in pF, holding any
+	 * value between 7.0 pF and 20.0 pF in 0.5 pF steps.
+	 */
+	uint32_t capvalue =
+		((slope + 56) * (CONFIG_SOC_HFXO_CAP_INT_VALUE_X2 - 14)
+		 + ((offset - 8) << 4) + 32) >> 6;
+
+	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, true, capvalue);
+#elif defined(CONFIG_SOC_HFXO_CAP_EXTERNAL)
+	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, false, 0);
+#endif
+
+#if defined(CONFIG_SOC_DCDC_NRF53X_APP)
+	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
+#endif
+#if defined(CONFIG_SOC_DCDC_NRF53X_NET)
+	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_RADIO, true);
+#endif
+#if defined(CONFIG_SOC_DCDC_NRF53X_HV)
+	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_HIGH, true);
+#endif
+
+#if defined(CONFIG_SOC_NRF_GPIO_FORWARDER_FOR_NRF5340)
+	static const uint8_t forwarded_psels[] = {
+		DT_FOREACH_STATUS_OKAY(nordic_nrf_gpio_forwarder, ALL_GPIOS_IN_FORWARDER)
+	};
+
+	for (int i = 0; i < ARRAY_SIZE(forwarded_psels); i++) {
+		soc_secure_gpio_pin_mcu_select(forwarded_psels[i], NRF_GPIO_PIN_SEL_NETWORK);
+	}
+
+#endif
+
+#if defined(CONFIG_PM_S2RAM)
+	enable_ram_retention();
+#endif /* CONFIG_PM_S2RAM */
+
+	return 0;
+}
+
+void arch_busy_wait(uint32_t time_us)
+{
+	nrfx_coredep_delay_us(time_us);
+}
+
+SYS_INIT(nordicsemi_nrf53_init, PRE_KERNEL_1, 0);
+
+#ifdef CONFIG_SOC_NRF53_RTC_PRETICK
+SYS_INIT(rtc_pretick_init, POST_KERNEL, 0);
+#endif

--- a/soc/arm/nordic_nrf/nrf53/soc.h
+++ b/soc/arm/nordic_nrf/nrf53/soc.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file SoC configuration macros for the
+ *       Nordic Semiconductor nRF53 family processors.
+ */
+
+#ifndef _NORDICSEMI_NRF53_SOC_H_
+#define _NORDICSEMI_NRF53_SOC_H_
+
+#include <soc_nrf_common.h>
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define FLASH_PAGE_ERASE_MAX_TIME_US  89700UL
+#define FLASH_PAGE_MAX_CNT  256UL
+#elif defined(CONFIG_SOC_NRF5340_CPUNET)
+#define FLASH_PAGE_ERASE_MAX_TIME_US  89700UL
+#define FLASH_PAGE_MAX_CNT  128UL
+#endif
+
+#endif /* _NORDICSEMI_NRF53_SOC_H_ */

--- a/soc/arm/nordic_nrf/nrf53/soc_cpu_idle.h
+++ b/soc/arm/nordic_nrf/nrf53/soc_cpu_idle.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file SoC extensions of cpu_idle.S for the Nordic Semiconductor nRF53 processors family.
+ */
+
+#define SOC_ON_EXIT_CPU_IDLE_4 \
+	__NOP(); \
+	__NOP(); \
+	__NOP(); \
+	__NOP();
+#define SOC_ON_EXIT_CPU_IDLE_8 \
+	SOC_ON_EXIT_CPU_IDLE_4 \
+	SOC_ON_EXIT_CPU_IDLE_4
+
+#if defined(CONFIG_SOC_NRF53_ANOMALY_168_WORKAROUND_FOR_EXECUTION_FROM_RAM)
+#define SOC_ON_EXIT_CPU_IDLE \
+	SOC_ON_EXIT_CPU_IDLE_8; \
+	SOC_ON_EXIT_CPU_IDLE_8; \
+	SOC_ON_EXIT_CPU_IDLE_8; \
+	__NOP(); \
+	__NOP();
+#elif defined(CONFIG_SOC_NRF53_ANOMALY_168_WORKAROUND)
+#define SOC_ON_EXIT_CPU_IDLE SOC_ON_EXIT_CPU_IDLE_8
+#endif

--- a/soc/arm/nordic_nrf/nrf53/sync_rtc.c
+++ b/soc/arm/nordic_nrf/nrf53/sync_rtc.c
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <nrfx_dppi.h>
+#include <hal/nrf_ipc.h>
+#include <helpers/nrfx_gppi.h>
+#include <zephyr/drivers/timer/nrf_rtc_timer.h>
+#include <zephyr/drivers/mbox.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(sync_rtc, CONFIG_SYNC_RTC_LOG_LEVEL);
+
+/* Arbitrary delay is used needed to handle cases when offset between cores is
+ * small and rtc synchronization process might not handle events on time.
+ * Setting high value prolongs synchronization process but setting too low may
+ * lead synchronization failure if offset between cores is small and/or there
+ * are significant interrupt handling latencies.
+ */
+#define RTC_SYNC_ARBITRARY_DELAY 100
+
+static uint32_t sync_cc;
+static int32_t nrf53_sync_offset = -EBUSY;
+
+union rtc_sync_channels {
+	uint32_t raw;
+	struct {
+		uint8_t ppi;
+		uint8_t rtc;
+		uint8_t ipc_out;
+		uint8_t ipc_in;
+	} ch;
+};
+
+/* Algorithm for establishing RTC offset on the network side.
+ *
+ * Assumptions:
+ * APP starts first thus its RTC is ahead. Only network will need to adjust its
+ * time. Because APP will capture the offset but NET needs it, algorithm
+ * consists of two stages: Getting offset on APP side, passing this offset to
+ * NET core. To keep it simple and independent from IPM protocols, value is passed
+ * using just IPC, PPI and RTC.
+ *
+ * 1st stage:
+ * APP: setup PPI connection from IPC_RECEIVE to RTC CAPTURE, enable interrupt
+ *      IPC received.
+ * NET: setup RTC CC for arbitrary offset from now, setup PPI from RTC_COMPARE to IPC_SEND
+ *      Record value set to CC.
+ *
+ * When APP will capture the value it needs to be passed to NET since it will be
+ * capable of calculating the offset since it know what counter value corresponds
+ * to the value captured on APP side.
+ *
+ * 2nd stage:
+ * APP: Sets Compare event for value = 2 * captured value + arbitrary offset
+ * NET: setup PPI from IPC_RECEIVE to RTC CAPTURE
+ *
+ * When NET RTC captures IPC event it takes CC value and knowing CC value previously
+ * used by NET and arbitrary offset (which is the same on APP and NET) is able
+ * to calculate exact offset between RTC counters.
+ *
+ * Note, arbitrary delay is used to accommodate for the case when NET-APP offset
+ * is small enough that interrupt latency would impact it. NET-APP offset depends
+ * on when NET core is reset and time when RTC system clock is initialized.
+ */
+
+/* Setup or clear connection from IPC_RECEIVE to RTC_CAPTURE
+ *
+ * @param channels Details about channels
+ * @param setup If true connection is setup, else it is cleared.
+ */
+static void ppi_ipc_to_rtc(union rtc_sync_channels channels, bool setup)
+{
+	nrf_ipc_event_t ipc_evt = nrf_ipc_receive_event_get(channels.ch.ipc_in);
+	uint32_t task_addr = z_nrf_rtc_timer_capture_task_address_get(channels.ch.rtc);
+
+	if (setup) {
+		nrfx_gppi_task_endpoint_setup(channels.ch.ppi, task_addr);
+		nrf_ipc_publish_set(NRF_IPC, ipc_evt, channels.ch.ppi);
+	} else {
+		nrfx_gppi_task_endpoint_clear(channels.ch.ppi, task_addr);
+		nrf_ipc_publish_clear(NRF_IPC, ipc_evt);
+	}
+}
+
+/* Setup or clear connection from RTC_COMPARE to IPC_SEND
+ *
+ * @param channels Details about channels
+ * @param setup If true connection is setup, else it is cleared.
+ */
+static void ppi_rtc_to_ipc(union rtc_sync_channels channels, bool setup)
+{
+	uint32_t evt_addr = z_nrf_rtc_timer_compare_evt_address_get(channels.ch.rtc);
+	nrf_ipc_task_t ipc_task = nrf_ipc_send_task_get(channels.ch.ipc_out);
+
+	if (setup) {
+		nrf_ipc_subscribe_set(NRF_IPC, ipc_task, channels.ch.ppi);
+		nrfx_gppi_event_endpoint_setup(channels.ch.ppi, evt_addr);
+	} else {
+		nrfx_gppi_event_endpoint_clear(channels.ch.ppi, evt_addr);
+		nrf_ipc_subscribe_clear(NRF_IPC, ipc_task);
+	}
+}
+
+/* Free DPPI and RTC channels */
+static void free_resources(union rtc_sync_channels channels)
+{
+	nrfx_err_t err;
+
+	nrfx_gppi_channels_disable(BIT(channels.ch.ppi));
+
+	z_nrf_rtc_timer_chan_free(channels.ch.rtc);
+
+	err = nrfx_dppi_channel_free(channels.ch.ppi);
+	__ASSERT_NO_MSG(err == NRFX_SUCCESS);
+}
+
+int z_nrf_rtc_timer_nrf53net_offset_get(void)
+{
+	if (!IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)) {
+		return -ENOSYS;
+	}
+
+	return nrf53_sync_offset;
+}
+
+static void rtc_cb(int32_t id, uint64_t cc_value, void *user_data)
+{
+	ARG_UNUSED(id);
+	ARG_UNUSED(cc_value);
+
+	union rtc_sync_channels channels;
+
+	channels.raw = (uint32_t)user_data;
+	ppi_rtc_to_ipc(channels, false);
+	if (IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP)) {
+		/* APP: Synchronized completed */
+		free_resources(channels);
+	} else {
+		/* Compare event generated, reconfigure PPI and wait for
+		 * IPC event from APP.
+		 */
+		ppi_ipc_to_rtc(channels, true);
+	}
+}
+
+static log_timestamp_t sync_rtc_timestamp_get(void)
+{
+	return (log_timestamp_t)(sys_clock_tick_get() + nrf53_sync_offset);
+}
+
+static void remote_callback(void *user_data)
+{
+	extern const struct log_link *log_link_ipc_get_link(void);
+
+	union rtc_sync_channels channels;
+	uint32_t cc;
+
+	channels.raw = (uint32_t)user_data;
+
+	cc = z_nrf_rtc_timer_compare_read(channels.ch.rtc);
+
+	/* Clear previous task,event */
+	ppi_ipc_to_rtc(channels, false);
+
+	if (IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP)) {
+		/* Setup new connection from RTC to IPC and set RTC to a new
+		 * interval that contains captured offset.
+		 */
+		ppi_rtc_to_ipc(channels, true);
+
+		z_nrf_rtc_timer_set(channels.ch.rtc, cc + cc + RTC_SYNC_ARBITRARY_DELAY,
+				    rtc_cb, (void *)channels.raw);
+	} else {
+		/* Synchronization completed */
+		free_resources(channels);
+		nrf53_sync_offset = cc - RTC_SYNC_ARBITRARY_DELAY - 2 * sync_cc;
+		if (IS_ENABLED(CONFIG_NRF53_SYNC_RTC_LOG_TIMESTAMP)) {
+			uint32_t offset_us =
+				(uint64_t)nrf53_sync_offset * 1000000 /
+				sys_clock_hw_cycles_per_sec();
+
+			log_set_timestamp_func(sync_rtc_timestamp_get,
+					       sys_clock_hw_cycles_per_sec());
+			LOG_INF("Updated timestamp to synchronized RTC by %d ticks (%dus)",
+					nrf53_sync_offset, offset_us);
+		}
+	}
+}
+
+static void mbox_callback(const struct device *dev, uint32_t channel,
+			  void *user_data, struct mbox_msg *data)
+{
+	struct mbox_channel ch;
+	int err;
+
+	mbox_init_channel(&ch, dev, channel);
+	err = mbox_set_enabled(&ch, false);
+
+	(void)err;
+	__ASSERT_NO_MSG(err == 0);
+
+	remote_callback(user_data);
+}
+
+static int mbox_rx_init(void *user_data)
+{
+	const struct device *dev;
+	struct mbox_channel channel;
+	int err;
+
+	dev = COND_CODE_1(CONFIG_MBOX, (DEVICE_DT_GET(DT_NODELABEL(mbox))), (NULL));
+	if (dev == NULL) {
+		return -ENODEV;
+	}
+
+	mbox_init_channel(&channel, dev, CONFIG_NRF53_SYNC_RTC_IPM_IN);
+
+	err = mbox_register_callback(&channel, mbox_callback, user_data);
+	if (err < 0) {
+		return err;
+	}
+
+	return mbox_set_enabled(&channel, true);
+}
+
+/* Setup RTC synchronization. */
+static int sync_rtc_setup(void)
+{
+	nrfx_err_t err;
+	union rtc_sync_channels channels;
+	int32_t sync_rtc_ch;
+	int rv;
+
+	err = nrfx_dppi_channel_alloc(&channels.ch.ppi);
+	if (err != NRFX_SUCCESS) {
+		rv = -ENODEV;
+		goto bail;
+	}
+
+	sync_rtc_ch = z_nrf_rtc_timer_chan_alloc();
+	if (sync_rtc_ch < 0) {
+		nrfx_dppi_channel_free(channels.ch.ppi);
+		rv = sync_rtc_ch;
+		goto bail;
+	}
+
+	channels.ch.rtc = (uint8_t)sync_rtc_ch;
+	channels.ch.ipc_out = CONFIG_NRF53_SYNC_RTC_IPM_OUT;
+	channels.ch.ipc_in = CONFIG_NRF53_SYNC_RTC_IPM_IN;
+
+	rv = mbox_rx_init((void *)channels.raw);
+	if (rv < 0) {
+		goto bail;
+	}
+
+	nrfx_gppi_channels_enable(BIT(channels.ch.ppi));
+
+	if (IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP)) {
+		ppi_ipc_to_rtc(channels, true);
+	} else {
+		ppi_rtc_to_ipc(channels, true);
+
+		uint32_t key = irq_lock();
+
+		sync_cc = z_nrf_rtc_timer_read() + RTC_SYNC_ARBITRARY_DELAY;
+		z_nrf_rtc_timer_set(channels.ch.rtc, sync_cc, rtc_cb, (void *)channels.raw);
+		irq_unlock(key);
+	}
+
+bail:
+	if (rv != 0) {
+		LOG_ERR("Failed synchronized RTC setup (err: %d)", rv);
+	}
+
+	return rv;
+}
+
+#if defined(CONFIG_MBOX_INIT_PRIORITY)
+BUILD_ASSERT(CONFIG_NRF53_SYNC_RTC_INIT_PRIORITY > CONFIG_MBOX_INIT_PRIORITY,
+		"RTC Sync must be initialized after MBOX driver.");
+#endif
+
+SYS_INIT(sync_rtc_setup, POST_KERNEL, CONFIG_NRF53_SYNC_RTC_INIT_PRIORITY);

--- a/soc/arm/nordic_nrf/nrf91/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf91/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library_sources(soc.c)

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9131_LACA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9131_LACA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF9131 MCU
+
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9131_LACA
+
+config SOC
+	default "nRF9131_LACA"
+
+config NUM_IRQS
+	default 65
+
+endif # SOC_NRF9131_LACA

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9151_LACA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9151_LACA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF9151 MCU
+
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9151_LACA
+
+config SOC
+	default "nRF9151_LACA"
+
+config NUM_IRQS
+	default 65
+
+endif # SOC_NRF9151_LACA

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9160_SICA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9160_SICA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF9160 MCU
+
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9160_SICA
+
+config SOC
+	default "nRF9160_SICA"
+
+config NUM_IRQS
+	default 65
+
+endif # SOC_NRF9160_SICA

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9161_LACA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9161_LACA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF9161 MCU
+
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9161_LACA
+
+config SOC
+	default "nRF9161_LACA"
+
+config NUM_IRQS
+	default 65
+
+endif # SOC_NRF9161_LACA

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.series
@@ -1,0 +1,17 @@
+# Nordic Semiconductor nRF91 MCU line
+
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF91X
+
+rsource "Kconfig.defconfig.nrf91*"
+
+config SOC_SERIES
+	default "nrf91"
+
+# If the kernel has timer support, enable the timer
+config NRF_RTC_TIMER
+	default y if SYS_CLOCK_EXISTS
+
+endif # SOC_SERIES_NRF91X

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -1,0 +1,35 @@
+# Nordic Semiconductor nRF91 MCU line
+
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NRF91X
+	bool "Nordic Semiconductor nRF91 series MCU"
+	select ARM
+	select CPU_CORTEX_M33
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_ARM_MPU
+	select CPU_HAS_NRF_IDAU
+	select CPU_HAS_FPU
+	select ARMV8_M_DSP
+	select SOC_FAMILY_NRF
+	imply XIP
+	select HAS_NRFX
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
+	select HAS_POWEROFF
+	help
+	  Enable support for NRF91 MCU series
+
+if SOC_SERIES_NRF91X
+config NRF_SPU_FLASH_REGION_SIZE
+	hex
+	default 0x8000
+	help
+	  FLASH region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_SIZE
+	hex
+	default 0x2000
+	help
+	  RAM region size for the NRF_SPU peripheral
+endif

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -1,0 +1,47 @@
+# Nordic Semiconductor nRF91 MCU line
+
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NRF91X
+
+config SOC_NRF9120
+	bool
+
+config SOC_NRF9160
+	bool
+
+choice
+	prompt "nRF91x MCU Selection"
+
+config SOC_NRF9160_SICA
+	bool "NRF9160_SICA"
+	select SOC_NRF9160
+
+# The nRF9161 is technically a SiP (System-in-Package) that consists of
+# the nRF9120 SoC and additional components like PMIC, FEM, and XTAL,
+# so for nrfx/MDK the nRF9120 SoC is to be indicated as the build target,
+# but since the nRF9161 is what a user can actually see on a board, using
+# only nRF9120 in the Zephyr build infrastructure might be confusing.
+# That's why in the top level of SoC definitions (for user-configurable
+# options in Kconfig, for example) the nRF9161 term is used and nRF9120
+# underneath.
+config SOC_NRF9161_LACA
+	bool "NRF9161_LACA"
+	select SOC_NRF9120
+
+config SOC_NRF9131_LACA
+	bool "NRF9131_LACA"
+	select SOC_NRF9120
+
+config SOC_NRF9151_LACA
+	bool "NRF9151_LACA"
+	select SOC_NRF9120
+
+endchoice
+
+config NRF_ENABLE_ICACHE
+	bool "Instruction cache (I-Cache)"
+	default y
+
+endif # SOC_SERIES_NRF91X

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for Nordic Semiconductor nRF91 family processor
+ *
+ * This module provides routines to initialize and support board-level hardware
+ * for the Nordic Semiconductor nRF91 family processor.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <soc/nrfx_coredep.h>
+#include <zephyr/logging/log.h>
+
+#include <cmsis_core.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
+static int nordicsemi_nrf91_init(void)
+{
+#ifdef CONFIG_NRF_ENABLE_ICACHE
+	/* Enable the instruction cache */
+	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
+#endif
+
+	return 0;
+}
+
+void arch_busy_wait(uint32_t time_us)
+{
+	nrfx_coredep_delay_us(time_us);
+}
+
+SYS_INIT(nordicsemi_nrf91_init, PRE_KERNEL_1, 0);

--- a/soc/arm/nordic_nrf/nrf91/soc.h
+++ b/soc/arm/nordic_nrf/nrf91/soc.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file SoC configuration macros for the Nordic Semiconductor nRF91 family processors.
+ */
+
+#ifndef _NORDICSEMI_NRF91_SOC_H_
+#define _NORDICSEMI_NRF91_SOC_H_
+
+#include <soc_nrf_common.h>
+
+#define FLASH_PAGE_ERASE_MAX_TIME_US	89700UL
+#define FLASH_PAGE_MAX_CNT		256UL
+
+#endif /* _NORDICSEMI_NRF91_SOC_H_ */

--- a/soc/arm/nordic_nrf/timing.c
+++ b/soc/arm/nordic_nrf/timing.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm/arch.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
+#include <nrfx.h>
+
+#if defined(CONFIG_NRF_RTC_TIMER)
+
+#define CYCLES_PER_SEC (16000000 / (1 << NRF_TIMER2->PRESCALER))
+
+void soc_timing_init(void)
+{
+	NRF_TIMER2->TASKS_CLEAR = 1; /* Clear Timer */
+	NRF_TIMER2->MODE = 0; /* Timer Mode */
+	NRF_TIMER2->PRESCALER = 0; /* 16M Hz */
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+	NRF_TIMER2->BITMODE = 0; /* 16 - bit */
+#else
+	NRF_TIMER2->BITMODE = 3; /* 32 - bit */
+#endif
+}
+
+void soc_timing_start(void)
+{
+	NRF_TIMER2->TASKS_START = 1;
+}
+
+void soc_timing_stop(void)
+{
+	NRF_TIMER2->TASKS_STOP = 1; /* Stop Timer */
+}
+
+timing_t soc_timing_counter_get(void)
+{
+	NRF_TIMER2->TASKS_CAPTURE[0] = 1;
+	return NRF_TIMER2->CC[0] * ((SystemCoreClock) / CYCLES_PER_SEC);
+}
+
+uint64_t soc_timing_cycles_get(volatile timing_t *const start,
+			       volatile timing_t *const end)
+{
+#if defined(CONFIG_SOC_SERIES_NRF51X)
+#define COUNTER_SPAN BIT(16)
+	if (*end >= *start) {
+		return (*end - *start);
+	} else {
+		return COUNTER_SPAN + *end - *start;
+	}
+#else
+	return (*end - *start);
+#endif
+}
+
+uint64_t soc_timing_freq_get(void)
+{
+	return SystemCoreClock;
+}
+
+uint64_t soc_timing_cycles_to_ns(uint64_t cycles)
+{
+	return (cycles) * (NSEC_PER_SEC) / (SystemCoreClock);
+}
+
+uint64_t soc_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count)
+{
+	return soc_timing_cycles_to_ns(cycles) / count;
+}
+
+uint32_t soc_timing_freq_get_mhz(void)
+{
+	return (uint32_t)(soc_timing_freq_get() / 1000000);
+}
+
+#endif

--- a/soc/arm/nordic_nrf/validate_base_addresses.c
+++ b/soc/arm/nordic_nrf/validate_base_addresses.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2019, 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <soc.h>
+#include <zephyr/devicetree.h>
+
+/*
+ * Account for MDK inconsistencies
+ */
+
+#if !defined(NRF_CTRLAP) && defined(NRF_CTRL_AP_PERI)
+#define NRF_CTRLAP NRF_CTRL_AP_PERI
+#endif
+
+#if !defined(NRF_GPIOTE0) && defined(NRF_GPIOTE)
+#define NRF_GPIOTE0 NRF_GPIOTE
+#endif
+
+#if !defined(NRF_I2S0) && defined(NRF_I2S)
+#define NRF_I2S0 NRF_I2S
+#endif
+
+#if !defined(NRF_P0) && defined(NRF_GPIO)
+#define NRF_P0 NRF_GPIO
+#endif
+
+#if !defined(NRF_PDM0) && defined(NRF_PDM)
+#define NRF_PDM0 NRF_PDM
+#endif
+
+#if !defined(NRF_QDEC0) && defined(NRF_QDEC)
+#define NRF_QDEC0 NRF_QDEC
+#endif
+
+#if !defined(NRF_SWI0) && defined(NRF_SWI_BASE)
+#define NRF_SWI0 ((0 * 0x1000) + NRF_SWI_BASE)
+#endif
+
+#if !defined(NRF_SWI1) && defined(NRF_SWI_BASE)
+#define NRF_SWI1 ((1 * 0x1000) + NRF_SWI_BASE)
+#endif
+
+#if !defined(NRF_SWI2) && defined(NRF_SWI_BASE)
+#define NRF_SWI2 ((2 * 0x1000) + NRF_SWI_BASE)
+#endif
+
+#if !defined(NRF_SWI3) && defined(NRF_SWI_BASE)
+#define NRF_SWI3 ((3 * 0x1000) + NRF_SWI_BASE)
+#endif
+
+#if !defined(NRF_SWI4) && defined(NRF_SWI_BASE)
+#define NRF_SWI4 ((4 * 0x1000) + NRF_SWI_BASE)
+#endif
+
+#if !defined(NRF_SWI5) && defined(NRF_SWI_BASE)
+#define NRF_SWI5 ((5 * 0x1000) + NRF_SWI_BASE)
+#endif
+
+#if !defined(NRF_WDT0) && defined(NRF_WDT)
+#define NRF_WDT0 NRF_WDT
+#endif
+
+#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
+#if !defined(NRF_POWER_GPREGRET1) && defined(NRF_POWER_BASE)
+#define NRF_POWER_GPREGRET1 (0x51c + NRF_POWER_BASE)
+#endif
+
+#if !defined(NRF_POWER_GPREGRET2) && defined(NRF_POWER_BASE)
+#define NRF_POWER_GPREGRET2 (0x520 + NRF_POWER_BASE)
+#endif
+#endif
+
+/**
+ * Check that a devicetree node's "reg" base address matches the
+ * correct value from the MDK.
+ *
+ * Node reg values are checked against MDK addresses regardless of
+ * their status.
+ *
+ * Using a node label allows the same file to work with multiple SoCs
+ * and devicetree configurations.
+ *
+ * @param lbl lowercase-and-underscores devicetree node label to check
+ * @param mdk_addr expected address from the Nordic MDK.
+ */
+#define CHECK_DT_REG(lbl, mdk_addr)					\
+	BUILD_ASSERT(							\
+		UTIL_OR(UTIL_NOT(DT_NODE_EXISTS(DT_NODELABEL(lbl))),	\
+			(DT_REG_ADDR(DT_NODELABEL(lbl)) == (uint32_t)(mdk_addr))))
+
+/**
+ * If a node label "lbl" might have different addresses depending on
+ * its compatible "compat", you can use this macro to pick the right
+ * one.
+ *
+ * @param lbl lowercase-and-underscores devicetree node label to check
+ * @param compat lowercase-and-underscores compatible to check
+ * @param addr_if_match MDK address to return if "lbl" has compatible "compat"
+ * @param addr_if_no_match MDK address to return otherwise
+ */
+#define NODE_ADDRESS(lbl, compat, addr_if_match, addr_if_no_match)	\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_NODELABEL(lbl), compat),	\
+		    (addr_if_match), (addr_if_no_match))
+
+#define CHECK_SPI_REG(lbl, num)						\
+	CHECK_DT_REG(lbl,						\
+		NODE_ADDRESS(lbl, nordic_nrf_spi, NRF_SPI##num,	\
+		NODE_ADDRESS(lbl, nordic_nrf_spim, NRF_SPIM##num,	\
+			     NRF_SPIS##num)))
+
+#define CHECK_I2C_REG(lbl, num)						\
+	CHECK_DT_REG(lbl,						\
+		NODE_ADDRESS(lbl, nordic_nrf_twi, NRF_TWI##num,		\
+		NODE_ADDRESS(lbl, nordic_nrf_twim, NRF_TWIM##num,	\
+			     NRF_TWIS##num)))
+
+#define CHECK_UART_REG(lbl, num)					\
+	CHECK_DT_REG(lbl,						\
+		NODE_ADDRESS(lbl, nordic_nrf_uart, NRF_UART##num,	\
+			     NRF_UARTE##num))
+
+CHECK_DT_REG(acl, NRF_ACL);
+CHECK_DT_REG(adc, NODE_ADDRESS(adc, nordic_nrf_adc, NRF_ADC, NRF_SAADC));
+CHECK_DT_REG(bprot, NRF_BPROT);
+CHECK_DT_REG(ccm, NRF_CCM);
+CHECK_DT_REG(clock, NRF_CLOCK);
+CHECK_DT_REG(comp, NODE_ADDRESS(comp, nordic_nrf_comp, NRF_COMP, NRF_LPCOMP));
+CHECK_DT_REG(cryptocell, NRF_CRYPTOCELL);
+CHECK_DT_REG(ctrlap, NRF_CTRLAP);
+CHECK_DT_REG(dcnf, NRF_DCNF);
+CHECK_DT_REG(dppic, NRF_DPPIC);
+CHECK_DT_REG(ecb, NRF_ECB);
+CHECK_DT_REG(egu0, NRF_EGU0);
+CHECK_DT_REG(egu1, NRF_EGU1);
+CHECK_DT_REG(egu2, NRF_EGU2);
+CHECK_DT_REG(egu3, NRF_EGU3);
+CHECK_DT_REG(egu4, NRF_EGU4);
+CHECK_DT_REG(egu5, NRF_EGU5);
+CHECK_DT_REG(ficr, NRF_FICR);
+CHECK_DT_REG(flash_controller, NRF_NVMC);
+CHECK_DT_REG(gpio0, NRF_P0);
+CHECK_DT_REG(gpio1, NRF_P1);
+CHECK_DT_REG(gpiote, NRF_GPIOTE);
+CHECK_DT_REG(gpiote0, NRF_GPIOTE0);
+CHECK_DT_REG(gpiote1, NRF_GPIOTE1);
+CHECK_DT_REG(gpiote20, NRF_GPIOTE20);
+CHECK_DT_REG(gpiote30, NRF_GPIOTE30);
+CHECK_DT_REG(gpiote130, NRF_GPIOTE130);
+CHECK_DT_REG(gpiote131, NRF_GPIOTE131);
+CHECK_I2C_REG(i2c0, 0);
+CHECK_I2C_REG(i2c1, 1);
+CHECK_DT_REG(i2c2, NRF_TWIM2);
+CHECK_DT_REG(i2c3, NRF_TWIM3);
+CHECK_DT_REG(i2s0, NRF_I2S0);
+CHECK_DT_REG(ipc, NRF_IPC);
+CHECK_DT_REG(kmu, NRF_KMU);
+CHECK_DT_REG(mutex, NRF_MUTEX);
+CHECK_DT_REG(mwu, NRF_MWU);
+CHECK_DT_REG(nfct, NRF_NFCT);
+CHECK_DT_REG(nrf_mpu, NRF_MPU);
+CHECK_DT_REG(oscillators, NRF_OSCILLATORS);
+CHECK_DT_REG(pdm0, NRF_PDM0);
+CHECK_DT_REG(power, NRF_POWER);
+CHECK_DT_REG(ppi, NRF_PPI);
+CHECK_DT_REG(pwm0, NRF_PWM0);
+CHECK_DT_REG(pwm1, NRF_PWM1);
+CHECK_DT_REG(pwm2, NRF_PWM2);
+CHECK_DT_REG(pwm3, NRF_PWM3);
+CHECK_DT_REG(qdec, NRF_QDEC0);	/* this should be the same node as qdec0 */
+CHECK_DT_REG(qdec0, NRF_QDEC0);
+CHECK_DT_REG(qdec1, NRF_QDEC1);
+CHECK_DT_REG(radio, NRF_RADIO);
+CHECK_DT_REG(regulators, NRF_REGULATORS);
+CHECK_DT_REG(reset, NRF_RESET);
+CHECK_DT_REG(rng, NRF_RNG);
+CHECK_DT_REG(rtc0, NRF_RTC0);
+CHECK_DT_REG(rtc1, NRF_RTC1);
+CHECK_DT_REG(rtc2, NRF_RTC2);
+CHECK_SPI_REG(spi0, 0);
+CHECK_SPI_REG(spi1, 1);
+CHECK_SPI_REG(spi2, 2);
+CHECK_DT_REG(spi3, NRF_SPIM3);
+CHECK_DT_REG(spi4, NRF_SPIM4);
+CHECK_DT_REG(spu, NRF_SPU);
+CHECK_DT_REG(swi0, NRF_SWI0);
+CHECK_DT_REG(swi1, NRF_SWI1);
+CHECK_DT_REG(swi2, NRF_SWI2);
+CHECK_DT_REG(swi3, NRF_SWI3);
+CHECK_DT_REG(swi4, NRF_SWI4);
+CHECK_DT_REG(swi5, NRF_SWI5);
+CHECK_DT_REG(temp, NRF_TEMP);
+CHECK_DT_REG(timer0, NRF_TIMER0);
+CHECK_DT_REG(timer1, NRF_TIMER1);
+CHECK_DT_REG(timer2, NRF_TIMER2);
+CHECK_DT_REG(timer3, NRF_TIMER3);
+CHECK_DT_REG(timer4, NRF_TIMER4);
+CHECK_DT_REG(timer00, NRF_TIMER00);
+CHECK_DT_REG(timer10, NRF_TIMER10);
+CHECK_DT_REG(timer20, NRF_TIMER20);
+CHECK_DT_REG(timer21, NRF_TIMER21);
+CHECK_DT_REG(timer22, NRF_TIMER22);
+CHECK_DT_REG(timer23, NRF_TIMER23);
+CHECK_DT_REG(timer24, NRF_TIMER24);
+CHECK_UART_REG(uart0, 0);
+CHECK_DT_REG(uart1, NRF_UARTE1);
+CHECK_DT_REG(uart2, NRF_UARTE2);
+CHECK_DT_REG(uart3, NRF_UARTE3);
+CHECK_DT_REG(uart00, NRF_UARTE00);
+CHECK_DT_REG(uart20, NRF_UARTE20);
+CHECK_DT_REG(uart21, NRF_UARTE21);
+CHECK_DT_REG(uart22, NRF_UARTE22);
+CHECK_DT_REG(uart30, NRF_UARTE30);
+CHECK_DT_REG(uart120, NRF_UARTE120);
+CHECK_DT_REG(uart130, NRF_UARTE130);
+CHECK_DT_REG(uart131, NRF_UARTE131);
+CHECK_DT_REG(uart132, NRF_UARTE132);
+CHECK_DT_REG(uart133, NRF_UARTE133);
+CHECK_DT_REG(uart134, NRF_UARTE134);
+CHECK_DT_REG(uart135, NRF_UARTE135);
+CHECK_DT_REG(uart136, NRF_UARTE136);
+CHECK_DT_REG(uart137, NRF_UARTE137);
+CHECK_DT_REG(uicr, NRF_UICR);
+CHECK_DT_REG(usbd, NRF_USBD);
+CHECK_DT_REG(usbreg, NRF_USBREGULATOR);
+CHECK_DT_REG(vmc, NRF_VMC);
+CHECK_DT_REG(wdt, NRF_WDT0);	/* this should be the same node as wdt0 */
+CHECK_DT_REG(wdt0, NRF_WDT0);
+CHECK_DT_REG(wdt1, NRF_WDT1);
+CHECK_DT_REG(wdt30, NRF_WDT30);
+CHECK_DT_REG(wdt31, NRF_WDT31);
+
+/* nRF51/nRF52-specific addresses */
+#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
+CHECK_DT_REG(gpregret1, NRF_POWER_GPREGRET1);
+CHECK_DT_REG(gpregret2, NRF_POWER_GPREGRET2);
+#endif

--- a/soc/arm/nordic_nrf/validate_enabled_instances.c
+++ b/soc/arm/nordic_nrf/validate_enabled_instances.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#define I2C_ENABLED(idx)  (IS_ENABLED(CONFIG_I2C) && \
+			   DT_NODE_HAS_STATUS(DT_NODELABEL(i2c##idx), okay))
+
+#define SPI_ENABLED(idx)  (IS_ENABLED(CONFIG_SPI) && \
+			   DT_NODE_HAS_STATUS(DT_NODELABEL(spi##idx), okay))
+
+#define UART_ENABLED(idx) (IS_ENABLED(CONFIG_SERIAL) && \
+			   (IS_ENABLED(CONFIG_SOC_SERIES_NRF53X) || \
+			    IS_ENABLED(CONFIG_SOC_SERIES_NRF91X)) && \
+			   DT_NODE_HAS_STATUS(DT_NODELABEL(uart##idx), okay))
+
+/*
+ * In most Nordic SoCs, SPI and TWI peripherals with the same instance number
+ * share certain resources and therefore cannot be used at the same time (in
+ * nRF53 and nRF91 Series this limitation concerns UART peripherals as well).
+ *
+ * In some SoCs, like nRF52810, there are only single instances of
+ * these peripherals and they are arranged in a different way, so this
+ * limitation does not apply.
+ *
+ * The build assertions below check if conflicting peripheral instances are not
+ * enabled simultaneously.
+ */
+
+#define CHECK(idx) \
+	!(I2C_ENABLED(idx) && SPI_ENABLED(idx)) && \
+	!(I2C_ENABLED(idx) && UART_ENABLED(idx)) && \
+	!(SPI_ENABLED(idx) && UART_ENABLED(idx))
+
+#define MSG(idx) \
+	"Only one of the following peripherals can be enabled: " \
+	"SPI"#idx", SPIM"#idx", SPIS"#idx", TWI"#idx", TWIM"#idx", TWIS"#idx \
+	IF_ENABLED(CONFIG_SOC_SERIES_NRF53X, (", UARTE"#idx)) \
+	IF_ENABLED(CONFIG_SOC_SERIES_NRF91X, (", UARTE"#idx)) \
+	". Check nodes with status \"okay\" in zephyr.dts."
+
+#if (!IS_ENABLED(CONFIG_SOC_NRF52810) &&	\
+	!IS_ENABLED(CONFIG_SOC_NRF52805) &&	\
+	!IS_ENABLED(CONFIG_SOC_NRF52811))
+BUILD_ASSERT(CHECK(0), MSG(0));
+#endif
+BUILD_ASSERT(CHECK(1), MSG(1));
+BUILD_ASSERT(CHECK(2), MSG(2));
+BUILD_ASSERT(CHECK(3), MSG(3));
+
+#if defined(CONFIG_SOC_NRF52811)
+BUILD_ASSERT(!(SPI_ENABLED(1) && I2C_ENABLED(0)),
+	     "Only one of the following peripherals can be enabled: "
+	     "SPI1, SPIM1, SPIS1, TWI0, TWIM0, TWIS0. "
+	     "Check nodes with status \"okay\" in zephyr.dts.");
+#endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  settings:
+    soc_root: .


### PR DESCRIPTION
TODO:

- [ ] `_ns` boards do not seem to work, needs to be investigated
- [x] If boards are moved to e.g. `tests/boards` (and `zephyr/module.yml` updated with `board_root: tests`), they no longer work
- [x] Device whether we want to keep the `board_root`, likely not. Now present to ease testing.