### PR TITLE
boards: nrf52840dk_nrf52840_v1: fix board identifier

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1.yaml
+++ b/boards/arm/nrf52840dk_nrf52840_v1/nrf52840dk_nrf52840_v1.yaml
@@ -1,4 +1,4 @@
-identifier: nrf52840dk_nrf52840
+identifier: nrf52840dk_nrf52840_v1
 name: nRF52840-DK-NRF52840
 type: mcu
 arch: arm


### PR DESCRIPTION
It was wrong.