### PR TITLE
soc: Update Kconfig.peripherals from sdk-zephyr bdda11b

### DIFF
--- a/soc/arm/nordic_nrf/common/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/common/Kconfig.peripherals
@@ -13,10 +13,12 @@ config HAS_HW_NRF_BPROT
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_BPROT))
 
 config HAS_HW_NRF_CC310
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_ARM_CRYPTOCELL_310))
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_ARM_CRYPTOCELL_310)) || \
+		 ($(dt_nodelabel_enabled,psa_rng) && SOC_SERIES_NRF91X)
 
 config HAS_HW_NRF_CC312
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_ARM_CRYPTOCELL_312))
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_ARM_CRYPTOCELL_312)) || \
+		 ($(dt_nodelabel_enabled,psa_rng) && SOC_NRF5340_CPUAPP)
 
 config HAS_HW_NRF_CCM
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_CCM))


### PR DESCRIPTION
That is the commit right before the upmerge that brought hwmv2 into NCS. Selectively chose which hunks to add.